### PR TITLE
PISP: #269 POST /authorizations changes

### DIFF
--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation.yaml
@@ -3713,7 +3713,7 @@ definitions:
     properties:
       authenticationInfo:
         $ref: '#/definitions/AuthenticationInfo'
-        description: OTP or QR Code if entered, otherwise empty.
+        description: OTP or QR Code or U2F if entered, otherwise empty.
       responseType:
         $ref: '#/definitions/AuthorizationResponse'
         description: Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.
@@ -4455,7 +4455,7 @@ definitions:
         description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
       authenticationType:
         $ref: '#/definitions/AuthenticationType'
-        description: OTP or QR Code, otherwise empty.
+        description: OTP or QR Code or U2F, otherwise empty.
       expiration:
         $ref: '#/definitions/DateTime'
         description: Can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, Merchant to know that their request has a time limit.

--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation.yaml
@@ -1805,7 +1805,10 @@ paths:
             “authenticationInfo”: 
             { 
                 “authentication”: “OTP”, 
-                “authenticationValue”: “1234” 
+                "authenticationValue": {
+                    "pinValue": "1234",
+                    "counter": 1
+                  } 
             },
             "responseType": "ENTERED"
           }
@@ -3101,8 +3104,8 @@ definitions:
       - QRCODE QR code used as One Time Password.
       - U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key. 
   
-  AuthenticationVal:
-    title: AuthenticationVal
+  PinValue:
+    title: PinValue
     #enum: [ $ref: '#/definitions/OtpValue', $ref: '#/definitions/QRCODE', $ref: '#/definitions/U2F']
     #Pattern below just indicates that the value can be an OTP or QRCODE or U2F. Effectively it only evaluates to the second part value QRCODE. This can be replaced by 'oneOf' or 'anyOf' construct once OpenAPI version 3 is released
     type: string
@@ -3662,14 +3665,14 @@ definitions:
     type: object
     description: Data model for the complex type AuthenticationValue
     properties:
-      authenticationVal:
-        $ref: '#/definitions/AuthenticationVal'
+      pinValue:
+        $ref: '#/definitions/PinValue'
         description: Authentication value.
       counter:
         $ref: '#/definitions/Counter'
         description: Sequential counter used for cloning detection. Present only for U2F authentication.
     required:
-    - authenticationVal
+    - pinValue
 
   AuthorizationsPostRequest:
     title: AuthorizationsPostRequest

--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation.yaml
@@ -1,0 +1,4664 @@
+swagger: "2.0"
+info:
+  version: "1.1"
+  title: Open API for FSP Interoperability (FSPIOP)
+  description: Based on API Definition.docx updated on 2018-03-13 Version 1.0. Note - The API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP header.
+  license:
+    name: Open API for FSP Interoperability (FSPIOP)
+    #url: http://example.com/
+#host: localhost:8081
+basePath: /fsp
+schemes:
+- http
+- https
+
+paths:
+  /participants/{ID}/error:
+    put:
+      description: If there is an error during FSP information creation in the server, the error callback PUT /participants/{ID}/error is used. The <ID> in the URI should contain the requestId that was used for the creation of the participant information.
+      summary: ParticipantsByIDAndError
+      tags:
+      - participants
+      operationId: ParticipantsByIDAndError
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            "errorInformation":
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /participants/{ID}:
+    put:
+      description: The callback PUT /participants/<ID> is used to inform the client of the result of the creation of the provided list of identities.
+      summary: ParticipantsByID
+      tags:
+      - participants
+      operationId: ParticipantsByIDPut
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ParticipantsIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “partyList”: 
+            [ 
+                { 
+                    partyId: {
+                      partyIdType: "PERSONAL_ID",
+                      partyIdentifier: "p123456789"
+                    }
+                }, 
+                { 
+                    partyId: {
+                      partyIdType: "PERSONAL_ID",
+                      partyIdentifier: "p987654321"
+                    }
+                }
+            ],
+            "currency": "USD"
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /participants/{Type}/{ID}/error:
+    put:
+      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback PUT /participants/<Type>/<ID>/error (or PUT /participants/<Type>/<ID>/<SubId>/error) is used.
+      summary: ParticipantsErrorByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsErrorByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Type'
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /participants/{Type}/{ID}/{SubId}/error:
+    put:
+      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback PUT /participants/<Type>/<ID>/error (or PUT /participants/<Type>/<ID>/<SubId>/error) is used.
+      summary: ParticipantsSubIdErrorByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsSubIdErrorByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Type'
+      - $ref: '#/parameters/ID'
+      - $ref: '#/parameters/SubId'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /participants/{Type}/{ID}/{SubId}:
+    parameters:
+    - $ref: '#/parameters/Type'
+    - $ref: '#/parameters/ID'
+    - $ref: '#/parameters/SubId'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /participants/<Type>/<ID> (or GET /participants/<Type>/<ID>/<SubId>) is used to find out in which FSP the requested Party, defined by <Type>, <ID> and optionally <SubId>, is located (for example, GET /participants/MSISDN/123456789, or GET /participants/BUSINESS/shoecompany/employee1). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request GET /participants/<Type>/<ID>?currency=XYZ should be used, where XYZ is the requested currency.
+      summary: ParticipantsSubIdByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /participants/<Type>/<ID> (or PUT /participants/<Type>/<ID>/<SubId>) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      summary: ParticipantsSubIdByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndID3
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ParticipantsTypeIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “fspId”: “1234” 
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    post:
+      description: The HTTP request POST /participants/<Type>/<ID> (or POST /participants/<Type>/<ID>/<SubId>) is used to create information in the server regarding the provided identity, defined by <Type>, <ID>, and optionally <SubId> (for example, POST /participants/MSISDN/123456789 or POST /participants/BUSINESS/shoecompany/employee1).
+      summary: ParticipantsSubIdByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndIDPost
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ParticipantsTypeIDSubIDPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          {
+            “fspId”: “1234”,
+            “currency”: “USD”
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    delete:
+      description: The HTTP request DELETE /participants/<Type>/<ID> (or DELETE /participants/<Type>/<ID>/<SubId>) is used to delete information in the server regarding the provided identity, defined by <Type> and <ID>) (for example, DELETE /participants/MSISDN/123456789), and optionally <SubId>. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request DELETE /participants/<Type>/<ID>?currency=XYZ should be used, where XYZ is the requested currency.
+        Note -  The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+      summary: ParticipantsSubIdByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndID2
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /participants/{Type}/{ID}:
+    parameters:
+    - $ref: '#/parameters/Type'
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /participants/<Type>/<ID> (or GET /participants/<Type>/<ID>/<SubId>) is used to find out in which FSP the requested Party, defined by <Type>, <ID> and optionally <SubId>, is located (for example, GET /participants/MSISDN/123456789, or GET /participants/BUSINESS/shoecompany/employee1). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request GET /participants/<Type>/<ID>?currency=XYZ should be used, where XYZ is the requested currency.
+      summary: ParticipantsByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /participants/<Type>/<ID> (or PUT /participants/<Type>/<ID>/<SubId>) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      summary: ParticipantsByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsByTypeAndID3
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ParticipantsTypeIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “fspId”: “1234” 
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    post:
+      description: The HTTP request POST /participants/<Type>/<ID> (or POST /participants/<Type>/<ID>/<SubId>) is used to create information in the server regarding the provided identity, defined by <Type>, <ID>, and optionally <SubId> (for example, POST /participants/MSISDN/123456789 or POST /participants/BUSINESS/shoecompany/employee1).
+      summary: ParticipantsByIDAndType
+      tags:
+      - participants
+      operationId: ParticipantsByIDAndType
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ParticipantsTypeIDSubIDPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          {
+            “fspId”: “1234”,
+            “currency”: “USD”
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    delete:
+      description: The HTTP request DELETE /participants/<Type>/<ID> (or DELETE /participants/<Type>/<ID>/<SubId>) is used to delete information in the server regarding the provided identity, defined by <Type> and <ID>) (for example, DELETE /participants/MSISDN/123456789), and optionally <SubId>. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request DELETE /participants/<Type>/<ID>?currency=XYZ should be used, where XYZ is the requested currency.
+        Note -  The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+      summary: ParticipantsByTypeAndID
+      tags:
+      - participants
+      operationId: ParticipantsByTypeAndID2
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /participants:
+    post:
+      description: The HTTP request POST /participants is used to create information in the server regarding the provided list of identities. This request should be used for bulk creation of FSP information for more than one Party. The optional currency parameter should indicate that each provided Party supports the currency
+      summary: Participants
+      tags:
+      - participants
+      operationId: Participants1
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ParticipantsPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          {
+            “requestId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”,
+            “partyList”:
+              [ {
+                “partyIdType”: “PERSONAL_ID”,
+                “partyIdentifier”: “16135551212”,
+                “partySubIdOrType”: “PASSPORT”,
+                “fspId”: “1234”
+              },
+              {
+                “partyIdType”: “PERSONAL_ID”,
+                “partyIdentifier”: “16135551234”,
+                “partySubIdOrType”: “DRIVING_LICENSE”,
+                “fspId”: “1234”,
+              } ],
+              "currency": "USD"
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /parties/{Type}/{ID}:
+    parameters:
+    - $ref: '#/parameters/Type'
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /parties/<Type>/<ID> (or GET /parties/<Type>/<ID>/<SubId>) is used to lookup information regarding the requested Party, defined by <Type>, <ID> and optionally <SubId> (for example, GET /parties/MSISDN/123456789, or GET /parties/BUSINESS/shoecompany/employee1).
+      summary: PartiesByTypeAndID
+      tags:
+      - parties
+      operationId: PartiesByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /parties/<Type>/<ID> (or PUT /parties/<Type>/<ID>/<SubId>) is used to inform the client of a successful result of the Party information lookup.
+      summary: PartiesByTypeAndID2
+      tags:
+      - parties
+      operationId: PartiesByTypeAndID2
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema: 
+          $ref: '#/definitions/PartiesTypeIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          {
+            "party":
+            {
+                "partyIdInfo":
+                {
+                  “partyIdType”: “PERSONAL_ID”, 
+                  “partyIdentifier”: “16135551212”,
+                  “partySubIdOrType”: “DRIVING_LICENSE”,
+                  “fspId”: “1234”
+                },
+                "merchantClassificationCode": "4321",
+                “name”: “Justin Trudeau”, 
+                “personalInfo”: 
+                { 
+                  “complexName”: 
+                    { 
+                      “firstName”: “Justin”, 
+                      “middleName”: “Pierre”, 
+                      “lastName”: “Trudeau”
+                    },
+                    “dateOfBirth”: “1971-12-25” 
+                }
+             }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /parties/{Type}/{ID}/error:
+    put:
+      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback PUT /parties/<Type>/<ID>/error (or PUT /parties/<Type>/<ID>/<SubId>/error) is used.
+      summary: PartiesErrorByTypeAndID
+      tags:
+      - parties
+      operationId: PartiesErrorByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Type'
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /parties/{Type}/{ID}/{SubId}:
+    parameters:
+    - $ref: '#/parameters/Type'
+    - $ref: '#/parameters/ID'
+    - $ref: '#/parameters/SubId'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /parties/<Type>/<ID> (or GET /parties/<Type>/<ID>/<SubId>) is used to lookup information regarding the requested Party, defined by <Type>, <ID> and optionally <SubId> (for example, GET /parties/MSISDN/123456789, or GET /parties/BUSINESS/shoecompany/employee1).
+      summary: PartiesSubIdByTypeAndID
+      tags:
+      - parties
+      operationId: PartiesSubIdByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /parties/<Type>/<ID> (or PUT /parties/<Type>/<ID>/<SubId>) is used to inform the client of a successful result of the Party information lookup.
+      summary: PartiesSubIdByTypeAndID
+      tags:
+      - parties
+      operationId: PartiesSubIdByTypeAndIDPut
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema: 
+          $ref: '#/definitions/PartiesTypeIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            "party":
+            {
+                "partyIdInfo":
+                {
+                  “partyIdType”: “PERSONAL_ID”, 
+                  “partyIdentifier”: “16135551212”,
+                  “partySubIdOrType”: “DRIVING_LICENSE”,
+                  “fspId”: “1234”
+                },
+                "merchantClassificationCode": "4321",
+                “name”: “Justin Trudeau”, 
+                “personalInfo”: 
+                { 
+                  “complexName”: 
+                    { 
+                      “firstName”: “Justin”, 
+                      “middleName”: “Pierre”, 
+                      “lastName”: “Trudeau”
+                    },
+                    “dateOfBirth”: “1971-12-25” 
+                }
+             }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /parties/{Type}/{ID}/{SubId}/error:
+    put:
+      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback PUT /parties/<Type>/<ID>/error (or PUT /parties/<Type>/<ID>/<SubId>/error) is used.
+      summary: PartiesSubIdErrorByTypeAndID
+      tags:
+      - parties
+      operationId: PartiesSubIdErrorByTypeAndID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/Type'
+      - $ref: '#/parameters/ID'
+      - $ref: '#/parameters/SubId'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transactionRequests/{ID}/error:
+    put:
+      description: If the server is unable to find or create a transaction request, or another processing error occurs, the error callback PUT /transactionRequests/<ID>/error is used. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request, or the <ID> that was used in the GET /transactionRequests/<ID>.
+      summary: TransactionRequestsErrorByID
+      tags:
+      - transactionRequests
+      operationId: TransactionRequestsErrorByID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”,
+                “errorDescription”: “This is an error description”,
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transactionRequests/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /transactionRequests/<ID> is used to get information regarding an earlier created or requested transaction request. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request.
+      summary: TransactionRequestsByID
+      tags:
+      - transactionRequests
+      operationId: TransactionRequestsByID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /transactionRequests/<ID> is used to inform the client of a requested or created transaction request. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request, or the <ID> that was used in the GET /transactionRequests/<ID>.
+      summary: TransactionRequestsByID
+      tags:
+      - transactionRequests
+      operationId: TransactionRequestsByIDPut
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/TransactionRequestsIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “transactionId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+            “transactionRequestState”: “RECEIVED”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transactionRequests:
+    post:
+      description: The HTTP request POST /transactionRequests is used to request the creation of a transaction request for the provided financial transaction in the server.
+      summary: TransactionRequests
+      tags:
+      - transactionRequests
+      operationId: TransactionRequests
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/TransactionRequestsPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “transactionRequestId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+            “payee”: 
+            { 
+                "partyIdInfo":
+                {
+                  “partyIdType”: “PERSONAL_ID”, 
+                  “partyIdentifier”: “16135551212”,
+                  “partySubIdOrType”: “DRIVING_LICENSE”,
+                  “fspId”: “1234”
+                },
+                "merchantClassificationCode": "4321",
+                “name”: “Justin Trudeau”, 
+                “personalInfo”: 
+                { 
+                    “complexName”: 
+                   { 
+                        “firstName”: “Justin”, 
+                        “middleName”: “Pierre”, 
+                        “lastName”: “Trudeau” 
+                    }, 
+                    “dateOfBirth”: “1971-12-25” 
+                } 
+             }, 
+            “payer”:  #PartyIdInfo type
+            {
+              “partyIdType”: “PERSONAL_ID”, 
+              “partyIdentifier”: “16135551212”,
+              “partySubIdOrType”: “DRIVING_LICENSE”,
+              “fspId”: “1234”
+            }, 
+            “amount”: 
+            { 
+                “currency”: “USD”, 
+                “amount”: “123.45” 
+            }, 
+            “transactionType”: 
+            { 
+                “scenario”: “DEPOSIT”, 
+                “subScenario”: “locally defined sub-scenario”, 
+                “initiator”: “PAYEE”, 
+                “initiatorType”: “CONSUMER”, 
+                “refundInfo”: 
+                { 
+                    “originalTransactionId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+                    “refundReason”: “free text indicating reason for the refund” 
+                }, 
+                “balanceOfPayments”: “123” 
+             }, 
+            “note”: “Free-text memo”, 
+            “geoCode”: 
+            { 
+                “latitude”: “+45.4215”, 
+                “longitude”: “+75.6972” 
+            },
+            “authenticationType”: “OTP”, 
+            “expiration”: “2016-05-24T08:38:08.699-04:00”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /quotes/{ID}/error:
+    put:
+      description: If the server is unable to find or create a quote, or some other processing error occurs, the error callback PUT /quotes/<ID>/error is used. The <ID> in the URI should contain the quoteId that was used for the creation of the quote, or the <ID> that was used in the GET /quotes/<ID>.
+      summary: QuotesByIDAndError
+      tags:
+      - quotes
+      operationId: QuotesByIDAndError
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /quotes/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /quotes/<ID> is used to get information regarding an earlier created or requested quote. The <ID> in the URI should contain the quoteId that was used for the creation of the quote.
+      summary: QuotesByID
+      tags:
+      - quotes
+      operationId: QuotesByID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /quotes/<ID> is used to inform the client of a requested or created quote. The <ID> in the URI should contain the quoteId that was used for the creation of the quote, or the <ID> that was used in the GET /quotes/<ID>GET /quotes/<ID>.
+      summary: QuotesByID
+      tags:
+      - quotes
+      operationId: QuotesByID1
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/QuotesIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “transferAmount”: 
+            { 
+                “currency”: “USD”, 
+                “amount”: “124.45” 
+            },
+            “payeeReceiveAmount”: 
+            { 
+                “currency”: “USD”, 
+                “amount”: “123.45” 
+            },
+            "payeeFspFee":
+            { 
+                “currency”: “USD”,
+                “amount”: “1.45” 
+            },
+            "payeeFspCommission":
+            { 
+                “currency”: “USD”, 
+                “amount”: "0" 
+            },
+            “expiration”: “2016-05-24T08:38:08.699-04:00”, 
+            “geoCode”:
+            { 
+                “latitude”: “+45.4215”, 
+                “longitude”: “+75.6972” 
+            },
+            “ilpPacket”: “AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA”,
+            "condition": "f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA",
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /quotes:
+    post:
+      description: The HTTP request POST /quotes is used to request the creation of a quote for the provided financial transaction in the server.
+      summary: Quotes
+      tags:
+      - quotes
+      operationId: Quotes
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/QuotesPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “quoteId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”,
+            “transactionId”: “a8323bc6-c228-4df2-ae82-e5a997baf899”,
+            “transactionRequestId”: “a8323bc6-c228-4df2-ae82-e5a997baf890”,
+            “payee”: 
+            { 
+                "partyIdInfo":
+                {
+                  “partyIdType”: “PERSONAL_ID”, 
+                  “partyIdentifier”: “16135551212”,
+                  “partySubIdOrType”: “DRIVING_LICENSE”,
+                  “fspId”: “1234”
+                },
+                "merchantClassificationCode": "4321",
+                “name”: “Justin Trudeau”, 
+                “personalInfo”: 
+                { 
+                    “complexName”: 
+                   { 
+                        “firstName”: “Justin”, 
+                        “middleName”: “Pierre”,
+                        “lastName”: “Trudeau” 
+                    }, 
+                    “dateOfBirth”: “1971-12-25” 
+                } 
+             }, 
+            “payer”: 
+            { 
+                "partyIdInfo":
+                {
+                  “partyIdType”: “PERSONAL_ID”, 
+                  “partyIdentifier”: “16135551212”,
+                  “partySubIdOrType”: “PASSPORT”,
+                  “fspId”: “1234”
+                },
+                "merchantClassificationCode": "1234",
+                “name”: “Donald Trump”, 
+                “personalInfo”: 
+                { 
+                    “complexName”: 
+                   { 
+                        “firstName”: “Donald”, 
+                        “middleName”: “John”, 
+                        “lastName”: “Trump” 
+                    }, 
+                    “dateOfBirth”: “1946-06-14” 
+                 } 
+            }, 
+            “amountType”: "SEND",
+            “amount”:
+            { 
+                “currency”: “USD”, 
+                “amount”: “123.45” 
+            },
+            “fees”:
+            { 
+                “currency”: “USD”, 
+                “amount”: “1.25” 
+            },
+            “transactionType”: 
+            { 
+                “scenario”: “DEPOSIT”, 
+                “subScenario”: “locally defined sub-scenario”, 
+                “initiator”: “PAYEE”, 
+                “initiatorType”: “CONSUMER”, 
+                “refundInfo”: 
+                { 
+                    “originalTransactionId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+                    “refundReason”: “free text indicating reason for the refund” 
+                }, 
+                “balanceOfPayments”: “123” 
+             }, 
+            “geoCode”: 
+            { 
+                “latitude”: “+45.4215”, 
+                “longitude”: “+75.6972” 
+            },
+            “note”: “Free-text memo”,
+            “expiration”: “2016-05-24T08:38:08.699-04:00”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503' 
+
+  /authorizations:
+    post:
+      description: The HTTP request POST /authorizations is used to request the Payer to enter the applicable credentials in the PISP system.
+      summary: AuthorizationsByID
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDPost
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/AuthorizationsPostRequest'
+      #Headers	  
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          {             
+            "authenticationType": "U2F",
+            "retriesLeft": 1,
+            "amount": {
+              "currency": "USD",
+              "amount": "18"
+            },
+            "transactionId": "2f169631-ef99-4cb1-96dc-91e8fc08f539",
+            "transactionRequestId": "02e28448-3c05-4059-b5f7-d518d0a2d8ea",
+            "quote": {
+              "transferAmount": {
+                "currency": "USD",
+                "amount": "18"
+              },
+              "payeeReceiveAmount": {
+                "currency": "USD",
+                "amount": "0"
+              },
+              "payeeFspFee": {
+                "currency": "USD",
+                "amount": "0"
+              },
+              "payeeFspCommission": {
+                "currency": "USD",
+                "amount": "0"
+              },
+              "expiration": "2020-05-17T15:28:54.250Z",
+              "geoCode": {
+                "latitude": "string",
+                "longitude": "string"
+              },
+              "ilpPacket": "string",
+              "condition": "string",
+              "extensionList": {
+                "extension": [
+                  {
+                    "key": "string",
+                    "value": "string"
+                  }
+                ]
+              }
+            }
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'          
+
+  /authorizations/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /authorizations/<ID> is used to request the Payer to enter the applicable credentials in the Payee FSP system. The <ID> in the URI should contain the transactionRequestID, received from the POST /transactionRequests service earlier in the process. This request requires a query string to be included in the URI, with the following key-value pairs -
+        authenticationType=<Type>, where <Type> value is a valid authentication type from the enumeration AuthenticationType.
+        retriesLeft==<NrOfRetries>, where <NrOfRetries> is the number of retries left before the financial transaction is rejected. <NrOfRetries> must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected.
+        amount=<Amount>, where <Amount> is the transaction amount that will be withdrawn from the Payer’s account. <Amount> must be expressed in the form of the data type Amount.
+        currency=<Currency>, where <Currency> is the transaction currency for the amount that will be withdrawn from the Payer’s account. The <Currency> value must be expressed in the form of the enumeration CurrencyCode.
+        An example URI containing all the required key-value pairs in the query string is the following - GET /authorization/3d492671-b7af-4f3f-88de-76169b1bdf88?authenticationType=OTP&retriesLeft=2&amount=102&currency=USD
+      summary: AuthorizationsByID
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDGet
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /authorizations/<ID> is used to inform the client of the result of a previously-requested authorization. The <ID> in the URI should contain the <ID> that was used in the GET /authorizations/<ID>.
+      summary: AuthorizationsByID
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDPut
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/AuthorizationsIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “authenticationInfo”: 
+            { 
+                “authentication”: “OTP”, 
+                “authenticationValue”: “1234” 
+            },
+            "responseType": "ENTERED"
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /authorizations/{ID}/error:
+    put:
+      description: If the server is unable to find the transaction request, or another processing error occurs, the error callback PUT /authorizations/<ID>/error is used. The <ID> in the URI should contain the <ID> that was used in the GET /authorizations/<ID>.
+      summary: AuthorizationsByIDAndError
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDAndError
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description”
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transfers/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /transfers/<ID> is used to get information regarding an earlier created or requested transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer.
+      summary: TransfersByIDGet
+      tags:
+      - transfers
+      operationId: TransfersByIDGet
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /transfers/<ID> is used to inform the client of a requested or created transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer, or the <ID> that was used in the GET /transfers/<ID>.
+      summary: TransfersByIDPut
+      tags:
+      - transfers
+      operationId: TransfersByIDPut
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/TransfersIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “fulfilment”: "WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8",
+            "completedTimestamp": “2016-05-24T08:38:08.699-04:00”,
+            "transferState": "COMMITTED",
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transfers/{ID}/error:
+    put:
+      description: If the server is unable to find or create a transfer, or another processing error occurs, the error callback PUT /transfers/<ID>/error is used. The <ID> in the URI should contain the transferId that was used for the creation of the transfer, or the <ID> that was used in the GET /transfers/<ID>.
+      summary: TransfersByIDAndError
+      tags:
+      - transfers
+      operationId: TransfersByIDAndError
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transfers:
+    post:
+      description: The HTTP request POST /transfers is used to request the creation of a transfer for the next ledger, and a financial transaction for the Payee FSP.
+      summary: Transfers
+      tags:
+      - transfers
+      operationId: transfers
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/TransfersPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “transferId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+            “payeeFsp”: “1234”, 
+            “payerFsp”: “5678”, 
+            “amount”: 
+            { 
+                “currency”: “USD”, 
+                “amount”: “123.45” 
+            }, 
+            “ilpPacket”: “AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA”,
+            "condition": "f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA",
+            “expiration”: “2016-05-24T08:38:08.699-04:00”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transactions/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /transactions/<ID> is used to get transaction information regarding a financial transaction created earlier. The <ID> in the URI should contain the transactionId that was used for the creation of the quote, as the transaction is created as part of another process (the transfer process).
+      summary: TransactionsByID
+      tags:
+      - transactions
+      operationId: TransactionsByID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /transactions/<ID> is used to inform the client of a requested transaction. The <ID> in the URI should contain the <ID> that was used in the GET /transactions/<ID>.
+      summary: TransactionsByID
+      tags:
+      - transactions
+      operationId: TransactionsByID1
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/TransactionsIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “completedTimestamp": “2016-05-24T08:38:08.699-04:00”, 
+            “transactionState”: “RECEIVED”,
+            “code”: “Test-Code”,
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /transactions/{ID}/error:
+    put:
+      description: If the server is unable to find or create a transaction, or another processing error occurs, the error callback PUT /transactions/<ID>/error is used. The <ID> in the URI should contain the <ID> that was used in the GET /transactions/<ID>.
+      summary: TransactionsErrorByID
+      tags:
+      - transactions
+      operationId: TransactionsErrorByID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            } 
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /bulkQuotes/{ID}/error:
+    put:
+      description: If the server is unable to find or create a bulk quote, or another processing error occurs, the error callback PUT /bulkQuotes/<ID>/error is used. The <ID> in the URI should contain the bulkQuoteId that was used for the creation of the bulk quote, or the <ID> that was used in the GET /bulkQuotes/<ID>.
+      summary: BulkQuotesErrorByID
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotesErrorByID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            } 
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /bulkQuotes/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /bulkQuotes/<ID> is used to get information regarding an earlier created or requested bulk quote. The <ID> in the URI should contain the bulkQuoteId that was used for the creation of the bulk quote.
+      summary: BulkQuotesByID
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotesByID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /bulkQuotes/<ID> is used to inform the client of a requested or created bulk quote. The <ID> in the URI should contain the bulkQuoteId that was used for the creation of the bulk quote, or the <ID> that was used in the GET /bulkQuotes/<ID>.
+      summary: BulkQuotesByID
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotesByID1
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/BulkQuotesIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “individualQuoteResults”: 
+            [ { 
+                quoteId: "b51ec534-ee48-4575-b6a9-ead2955b8069",
+                payee: 
+                { 
+                    partyIdInfo:
+                    {
+                      partyIdType: “PERSONAL_ID”, 
+                      partyIdentifier: “16135551212”,
+                      partySubIdOrType: “DRIVING_LICENSE”,
+                      fspId: “1234”
+                    },
+                    merchantClassificationCode: "4321",
+                    name: “Justin Trudeau”, 
+                    personalInfo: 
+                    { 
+                      complexName: 
+                      { 
+                        firstName: “Justin”, 
+                        middleName: “Pierre”, 
+                        lastName: “Trudeau”
+                      }, 
+                      dateOfBirth: “1971-12-25” 
+                    }
+                 },
+                receiveAmount:
+                { 
+                    currency: "USD", 
+                    amount: "123.45" 
+                },
+                payeeFspFee:
+                { 
+                    currency: "USD", 
+                    amount: "1.45" 
+                },
+                payeeFspCommission:
+                { 
+                    currency: "USD", 
+                    amount: "1.45" 
+                },
+                ilpPacket: "AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA",
+                condition: "f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA",
+                errorInformation: 
+                {
+                  errorCode: "5100",
+                  errorDescription: "This is an error description",
+                  extensionList:
+                  {
+                    extension:
+                    [ 
+                        { 
+                            “key”: “errorDescription”, 
+                            “value”: “This is a more detailed error description” 
+                        }, 
+                        { 
+                            “key”: “errorDescription”, 
+                            “value”: “This is a more detailed error description” 
+                        }
+                    ]
+                  }
+                },
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+              }
+            ],
+            “expiration”: “2016-05-24T08:38:08.699-04:00”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /bulkQuotes:
+    post:
+      description: The HTTP request POST /bulkQuotes is used to request the creation of a bulk quote for the provided financial transactions in the server.
+      summary: BulkQuotes
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotes
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/BulkQuotesPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “bulkQuoteId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+            “payer”: 
+            { 
+                "partyIdInfo":
+                {
+                  “partyIdType”: “PERSONAL_ID”, 
+                  “partyIdentifier”: “16135551212”,
+                  “partySubIdOrType”: “PASSPORT”,
+                  “fspId”: “1234”
+                },
+                "merchantClassificationCode": "1234",
+                “name”: “Justin Trudeau”, 
+                “personalInfo”: 
+                { 
+                    “complexName”: 
+                   { 
+                        “firstName”: “Justin”, 
+                        “middleName”: “Pierre”, 
+                        “lastName”: “Trudeau” 
+                    }, 
+                    “dateOfBirth”: “1971-12-25” 
+                } 
+            }, 
+            “geoCode”: { 
+                “latitude”: “+45.4215”, 
+                “longitude”: “+75.6972” 
+            }, 
+            “individualQuotes”: 
+            [ { 
+                “quoteId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”,
+                “transactionId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”,
+                “payee”: 
+                { 
+                    "partyIdInfo":
+                    {
+                      “partyIdType”: “PERSONAL_ID”, 
+                      “partyIdentifier”: “16135551212”,
+                      “partySubIdOrType”: “PASSPORT”,
+                      “fspId”: “1234”
+                    },
+                    "merchantClassificationCode": "1234",
+                    “name”: “Justin Trudeau”, 
+                    “personalInfo”: 
+                    { 
+                        “complexName”: 
+                       { 
+                            “firstName”: “Justin”, 
+                            “middleName”: “Pierre”, 
+                            “lastName”: “Trudeau” 
+                        }, 
+                        “dateOfBirth”: “1971-12-25” 
+                    } 
+                 },
+                “amountType”: "RECEIVE",
+                “amount”:
+                { 
+                    “currency”: “USD”, 
+                    “amount”: “123.45” 
+                },
+                “fees”:
+                { 
+                    “currency”: “USD”, 
+                    “amount”: “1.45” 
+                },
+                “transactionType”: 
+                { 
+                    “scenario”: “DEPOSIT”, 
+                    “subScenario”: “locally defined sub-scenario”, 
+                    “initiator”: “PAYEE”, 
+                    “initiatorType”: “CONSUMER”, 
+                    “refundInfo”: 
+                    { 
+                        “originalTransactionId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+                        “refundReason”: “free text indicating reason for the refund” 
+                    }, 
+                    “balanceOfPayments”: “123” 
+                 },
+                “note”: “Note sent to Payee”,
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+                } ], 
+            “expiration”: “2016-05-24T08:38:08.699-04:00”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /bulkTransfers/{ID}:
+    parameters:
+    - $ref: '#/parameters/ID'
+    #Headers
+    - $ref: '#/parameters/Content-Type'
+    - $ref: '#/parameters/Date'
+    - $ref: '#/parameters/X-Forwarded-For'
+    - $ref: '#/parameters/FSPIOP-Source'
+    - $ref: '#/parameters/FSPIOP-Destination'
+    - $ref: '#/parameters/FSPIOP-Encryption'
+    - $ref: '#/parameters/FSPIOP-Signature'
+    - $ref: '#/parameters/FSPIOP-URI'
+    - $ref: '#/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request GET /bulkTransfers/<ID> is used to get information regarding an earlier created or requested bulk transfer. The <ID> in the URI should contain the bulkTransferId that was used for the creation of the bulk transfer.
+      summary: BulkTransferByID
+      tags:
+      - bulkTransfers
+      operationId: BulkTransferByID
+      produces:
+      - application/json
+      parameters:
+      #Headers
+      - $ref: '#/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+    put:
+      description: The callback PUT /bulkTransfers/<ID> is used to inform the client of a requested or created bulk transfer. The <ID> in the URI should contain the bulkTransferId that was used for the creation of the bulk transfer (POST /bulkTransfers), or the <ID> that was used in the GET /bulkTransfers/<ID>.
+      summary: BulkTransfersByIDPut
+      tags:
+      - bulkTransfers
+      operationId: BulkTransfersByIDPut
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/BulkTransfersIDPutResponse'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      x-examples:
+        "application/json":
+          { 
+            “completedTimestamp": “2016-05-24T08:38:08.699-04:00”, 
+            “individualTransferResults”: 
+            [ 
+                {
+                    “transferId”: “b51ec534-ee48-4575-b6a9-ead2955b8069”, 
+                    “fulfilment”: “WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8”, 
+                    “errorInformation”: 
+                    {
+                        “errorCode”: “5100”, 
+                        “errorDescription”: “This is an error description”, 
+                        extensionList:
+                        {
+                          extension:
+                          [ 
+                              { 
+                                  “key”: “errorDescription”, 
+                                  “value”: “This is a more detailed error description” 
+                              }, 
+                              { 
+                                  “key”: “errorDescription”, 
+                                  “value”: “This is a more detailed error description” 
+                              }
+                          ]
+                        }
+                    },
+                    extensionList:
+                    {
+                      extension:
+                      [ 
+                          { 
+                              “key”: “errorDescription”, 
+                              “value”: “This is a more detailed error description” 
+                          }, 
+                          { 
+                              “key”: “errorDescription”, 
+                              “value”: “This is a more detailed error description” 
+                          }
+                      ]
+                    }
+                },
+                { 
+                    “transferId”: “a8323bc6-c228-4df2-ae82-e5a997baf890”, 
+                    “fulfilment”: “WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8”, 
+                    “errorInformation”: 
+                    {
+                        “errorCode”: “5100”, 
+                        “errorDescription”: “This is an error description”, 
+                        extensionList:
+                        {
+                          extension:
+                          [ 
+                              { 
+                                  “key”: “errorDescription”, 
+                                  “value”: “This is a more detailed error description” 
+                              }, 
+                              { 
+                                  “key”: “errorDescription”, 
+                                  “value”: “This is a more detailed error description” 
+                              }
+                          ]
+                        }
+                    },
+                    extensionList:
+                    {
+                      extension:
+                      [ 
+                          { 
+                              “key”: “errorDescription”, 
+                              “value”: “This is a more detailed error description” 
+                          }, 
+                          { 
+                              “key”: “errorDescription”, 
+                              “value”: “This is a more detailed error description” 
+                          }
+                      ]
+                    }
+                }
+            ],
+            “bulkTransferState”: “COMPLETED”, 
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /bulkTransfers:
+    post:
+      description: The HTTP request POST /bulkTransfers is used to request the creation of a bulk transfer in the server.
+      summary: BulkTransfers
+      tags:
+      - bulkTransfers
+      operationId: BulkTransfers
+      produces:
+      - application/json
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/BulkTransfersPostRequest'
+      #Headers
+      - $ref: '#/parameters/Accept'
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            bulkTransferId: "b51ec534-ee48-4575-b6a9-ead2955b8069", 
+            bulkQuoteId: "b51ec534-ee48-4575-b6a9-ead2955b8069", 
+            payeeFsp: "1234",
+            payerFsp: "5678",
+            individualTransfers: 
+            [ { 
+                transferId: "b51ec534-ee48-4575-b6a9-ead2955b8069", 
+                transferAmount: 
+                { 
+                    currency: "USD", 
+                    amount: "123.45" 
+                }, 
+                ilpPacket: "AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA",
+                condition: "f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA",
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+              }, 
+              { 
+                transferId: "b51ec534-ee48-4575-b6a9-ead2955b8069", 
+                transferAmount:
+                { 
+                    currency: "USD", 
+                    amount: "1233.55" 
+                }, 
+                ilpPacket: "AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA",
+                condition: "f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA",
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+              }
+            ], 
+            expiration: "2016-05-24T08:38:08.699-04:00",
+            extensionList:
+            {
+              extension:
+              [ 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }, 
+                  { 
+                      “key”: “errorDescription”, 
+                      “value”: “This is a more detailed error description” 
+                  }
+              ]
+            }
+          }
+      responses:
+        202:
+          $ref: '#/responses/Response202'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+  /bulkTransfers/{ID}/error:
+    put:
+      description: If the server is unable to find or create a bulk transfer, or another processing error occurs, the error callback PUT /bulkTransfers/<ID>/error is used. The <ID> in the URI should contain the bulkTransferId that was used for the creation of the bulk transfer (POST /bulkTransfers), or the <ID> that was used in the GET /bulkTransfers/<ID>.
+      summary: BulkTransfersErrorByID
+      tags:
+      - bulkTransfers
+      operationId: BulkTransfersErrorByID
+      produces:
+      - application/json
+      parameters:
+      - $ref: '#/parameters/ID'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/ErrorInformationObject'
+      #Headers
+      - $ref: '#/parameters/Content-Length'
+      - $ref: '#/parameters/Content-Type'
+      - $ref: '#/parameters/Date'
+      - $ref: '#/parameters/X-Forwarded-For'
+      - $ref: '#/parameters/FSPIOP-Source'
+      - $ref: '#/parameters/FSPIOP-Destination'
+      - $ref: '#/parameters/FSPIOP-Encryption'
+      - $ref: '#/parameters/FSPIOP-Signature'
+      - $ref: '#/parameters/FSPIOP-URI'
+      - $ref: '#/parameters/FSPIOP-HTTP-Method'
+      x-examples:
+        "application/json":
+          { 
+            “errorInformation”: 
+            {
+                “errorCode”: “5100”, 
+                “errorDescription”: “This is an error description”, 
+                extensionList:
+                {
+                  extension:
+                  [ 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }, 
+                      { 
+                          “key”: “errorDescription”, 
+                          “value”: “This is a more detailed error description” 
+                      }
+                  ]
+                }
+            } 
+          }
+      responses:
+        200:
+          $ref: '#/responses/Response200'
+        400:
+          $ref: '#/responses/ErrorResponse400'
+        401:
+          $ref: '#/responses/ErrorResponse401'
+        403:
+          $ref: '#/responses/ErrorResponse403'
+        404:
+          $ref: '#/responses/ErrorResponse404'
+        405:
+          $ref: '#/responses/ErrorResponse405'
+        406:
+          $ref: '#/responses/ErrorResponse406'
+        501:
+          $ref: '#/responses/ErrorResponse501'
+        503:
+          $ref: '#/responses/ErrorResponse503'
+
+definitions:
+  Amount:
+    title: Amount
+    type: string
+    pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+    description: The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.
+  AmountType:
+    title: AmountType
+    type: string
+    enum:
+    - SEND
+    - RECEIVE
+    description: Below are the allowed values for the enumeration AmountType 
+      - SEND Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees.
+      - RECEIVE Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver exclusive fees.
+  
+  AuthenticationType:
+    title: AuthenticationTypeEnum
+    type: string
+    enum:
+    - OTP
+    - QRCODE
+    - U2F
+    description: Below are the allowed values for the enumeration AuthenticationType.
+      - OTP One-time password generated by the Payer FSP.
+      - QRCODE QR code used as One Time Password.
+      - U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key. 
+  
+  AuthenticationVal:
+    title: AuthenticationVal
+    #enum: [ $ref: '#/definitions/OtpValue', $ref: '#/definitions/QRCODE', $ref: '#/definitions/U2F']
+    #Pattern below just indicates that the value can be an OTP or QRCODE or U2F. Effectively it only evaluates to the second part value QRCODE. This can be replaced by 'oneOf' or 'anyOf' construct once OpenAPI version 3 is released
+    type: string
+    pattern: ^\d{3,10}$|^\S{1,64}$
+    description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
+  
+  AuthorizationResponse:
+    title: AuthorizationResponse
+    type: string
+    enum:
+    - ENTERED
+    - REJECTED
+    - RESEND
+    description: Below are the allowed values for the enumeration
+      - ENTERED Consumer entered the authentication value.
+      - REJECTED Consumer rejected the transaction.
+      - RESEND Consumer requested to resend the authentication value.
+  BalanceOfPayments:
+    title: BalanceOfPayments
+    type: string
+    pattern: ^[1-9]\d{2}$
+    description: (BopCode) The API data type BopCode is a JSON String of 3 characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. https://www.imf.org/external/np/sta/bopcode/
+  BinaryString:
+    type: string
+    pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+    description: The API data type BinaryString is a JSON String. The string is a base64url  encoding of a string of raw bytes, where padding (character ‘=’) is added at the end of the data if needed to ensure that the string is a multiple of 4 characters. The length restriction indicates the allowed number of characters.
+  BinaryString32:
+    type: string
+    pattern: ^[A-Za-z0-9-_]{43}$
+    description: The API data type BinaryString32 is a fixed size version of the API data type BinaryString, where the raw underlying data is always of 32 bytes. The data type BinaryString32 should not use a padding character as the size of the underlying data is fixed.
+  BulkTransferState:
+    title: BulkTransactionStateEnum
+    type: string
+    enum:
+    - RECEIVED
+    - PENDING
+    - ACCEPTED
+    - PROCESSING
+    - COMPLETED
+    - REJECTED
+    description: Below are the allowed values for the enumeration
+      - RECEIVED Payee FSP has received the bulk transfer from the Payer FSP.
+      - PENDING Payee FSP has validated the bulk transfer.
+      - ACCEPTED Payee FSP has accepted to process the bulk transfer.
+      - PROCESSING Payee FSP has started to transfer fund to the Payees.
+      - COMPLETED Payee FSP has completed transfer of funds to the Payees.
+      - REJECTED Payee FSP has rejected to process the bulk transfer.
+  Code:
+    title: Code
+    type: string
+    pattern: ^[0-9a-zA-Z]{4,32}$
+    description: Any code/token returned by the Payee FSP (TokenCode Type).
+  CorrelationId:
+    title: CorrelationId
+    type: string
+    pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+    description: Identifier that correlates all messages of the same sequence. The API data type UUID (Universally Unique Identifier) is a JSON String in canonical format, conforming to RFC 4122, that is restricted by a regular expression for interoperability reasons. An UUID is always 36 characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+  Currency:
+    title: CurrencyEnum
+    description: The currency codes defined in ISO 4217 as three-letter alphabetic codes are used as the standard naming representation for currencies.
+    type: string
+    minLength: 3
+    maxLength: 3
+    enum:
+    - AED
+    - AFN
+    - ALL
+    - AMD
+    - ANG
+    - AOA
+    - ARS
+    - AUD
+    - AWG
+    - AZN
+    - BAM
+    - BBD
+    - BDT
+    - BGN
+    - BHD
+    - BIF
+    - BMD
+    - BND
+    - BOB
+    - BRL
+    - BSD
+    - BTN
+    - BWP
+    - BYN
+    - BZD
+    - CAD
+    - CDF
+    - CHF
+    - CLP
+    - CNY
+    - COP
+    - CRC
+    - CUC
+    - CUP
+    - CVE
+    - CZK
+    - DJF
+    - DKK
+    - DOP
+    - DZD
+    - EGP
+    - ERN
+    - ETB
+    - EUR
+    - FJD
+    - FKP
+    - GBP
+    - GEL
+    - GGP
+    - GHS
+    - GIP
+    - GMD
+    - GNF
+    - GTQ
+    - GYD
+    - HKD
+    - HNL
+    - HRK
+    - HTG
+    - HUF
+    - IDR
+    - ILS
+    - IMP
+    - INR
+    - IQD
+    - IRR
+    - ISK
+    - JEP
+    - JMD
+    - JOD
+    - JPY
+    - KES
+    - KGS
+    - KHR
+    - KMF
+    - KPW
+    - KRW
+    - KWD
+    - KYD
+    - KZT
+    - LAK
+    - LBP
+    - LKR
+    - LRD
+    - LSL
+    - LYD
+    - MAD
+    - MDL
+    - MGA
+    - MKD
+    - MMK
+    - MNT
+    - MOP
+    - MRO
+    - MUR
+    - MVR
+    - MWK
+    - MXN
+    - MYR
+    - MZN
+    - NAD
+    - NGN
+    - NIO
+    - NOK
+    - NPR
+    - NZD
+    - OMR
+    - PAB
+    - PEN
+    - PGK
+    - PHP
+    - PKR
+    - PLN
+    - PYG
+    - QAR
+    - RON
+    - RSD
+    - RUB
+    - RWF
+    - SAR
+    - SBD
+    - SCR
+    - SDG
+    - SEK
+    - SGD
+    - SHP
+    - SLL
+    - SOS
+    - SPL
+    - SRD
+    - STD
+    - SVC
+    - SYP
+    - SZL
+    - THB
+    - TJS
+    - TMT
+    - TND
+    - TOP
+    - TRY
+    - TTD
+    - TVD
+    - TWD
+    - TZS
+    - UAH
+    - UGX
+    - USD
+    - UYU
+    - UZS
+    - VEF
+    - VND
+    - VUV
+    - WST
+    - XAF
+    - XCD
+    - XDR
+    - XOF
+    - XPF
+    - YER
+    - ZAR
+    - ZMW
+    - ZWD
+  Counter:
+    title: Counter
+    $ref: '#/definitions/Integer'
+    description: Sequential counter used for cloning detection. Present only for U2F authentication.  
+  Date:
+    title: Date
+    type: string
+    pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+    description: The API data type Date is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+      This format, as specified in ISO 8601, contains a date only. A more readable version of the format is yyyy-MM-dd. Examples - "1982-05-23", "1987-08-05”
+  DateOfBirth:
+    title: DateofBirth (type Date)
+    type: string
+    pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+    description: Date of Birth of the Party.
+  DateTime:
+    title: DateTime
+    type: string
+    pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+    description: The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+      The format is according to ISO 8601, expressed in a combined date, time and time zone format. A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples -  "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z indicates Zulu time zone, same as UTC).
+  ErrorCode:
+    title: ErrorCode
+    type: string
+    pattern: ^[1-9]\d{3}$
+    description: The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represents the specific error.
+  ErrorDescription:
+    title: ErrorDescription
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Error description string.
+  ExtensionKey:
+    title: ExtensionKey
+    type: string
+    minLength: 1
+    maxLength: 32
+    description: Extension key.
+  ExtensionValue:
+    title: ExtensionValue
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Extension value.
+  FirstName:
+    title: FirstName
+    type: string
+    minLength: 1
+    maxLength: 128
+    pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+    description: First name of the Party (Name Type).
+  FspId:
+    title: FspId
+    type: string
+    minLength: 1
+    maxLength: 32
+    description: FSP identifier.
+  IlpCondition:
+    title: IlpCondition
+    type: string
+    pattern: ^[A-Za-z0-9-_]{43}$
+    maxLength: 48
+    description: Condition that must be attached to the transfer by the Payer.
+  IlpFulfilment:
+    title: IlpFulfilment
+    type: string
+    pattern: ^[A-Za-z0-9-_]{43}$
+    maxLength: 48
+    description: Fulfilment that must be attached to the transfer by the Payee.
+  IlpPacket:
+    title: IlpPacket
+    type: string
+    pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+    minLength: 1
+    maxLength: 32768
+    description: Information for recipient (transport layer information).
+  Integer:
+    title: Integer
+    type: string
+    pattern: ^[1-9]\d*$
+    description: The API data type Integer is a JSON String consisting of digits only. Negative numbers and leading zeroes are not allowed. The data type is always limited to a specific number of digits.
+  LastName:
+    title: LastName
+    type: string
+    minLength: 1
+    maxLength: 128
+    pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+    description: Last name of the Party (Name Type).
+  Latitude:
+    title: Latitude
+    type: string
+    pattern: ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+    description: The API data type Latitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+  Longitude:
+    title: Longitude
+    type: string
+    pattern: ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+    description: The API data type Longitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+  MerchantClassificationCode:
+    title: MerchantClassificationCode
+    type: string
+    pattern: ^[\d]{1,4}$
+    description: A limited set of pre-defined numbers. This list would be a limited set of numbers identifying a set of popular merchant types like School Fees, Pubs and Restaurants, Groceries, etc.
+  MiddleName:
+    title: MiddleName
+    type: string
+    minLength: 1
+    maxLength: 128
+    pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+    description: Middle name of the Party (Name Type).
+  Name:
+    title: Name
+    type: string
+    pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+    description: The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally not used in a name.
+      Regular Expression - The regular expression for restricting the Name type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,) and space characters ( ).
+      Note -  In some programming languages, Unicode support must be specifically enabled. For example, if Java is used the flag UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+  Note:
+    title: Note
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Memo assigned to transaction
+  OtpValue:
+    title: OtpValue
+    type: string
+    pattern: ^\d{3,10}$
+    description: The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. Negative numbers are not allowed. One or more leading zeros are allowed.
+  PartyIdentifier:
+    title: PartyIdentifier
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Identifier of the Party.
+  PartyIdType:
+    title: PartyIdTypeEnum
+    type: string
+    enum:
+    - MSISDN
+    - EMAIL
+    - PERSONAL_ID
+    - BUSINESS
+    - DEVICE
+    - ACCOUNT_ID
+    - IBAN
+    - ALIAS
+    description: Below are the allowed values for the enumeration
+      - MSISDN An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the ITU-T E.164 standard. Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix.
+      - EMAIL An email is used as reference to a participant. The format of the email should be according to the informational RFC 3696.
+      - PERSONAL_ID A personal identifier is used as reference to a participant. Examples of personal identification are passport number, birth certificate number, and national registration number. The identifier number is added in the PartyIdentifier element. The personal identifier type is added in the PartySubIdOrType element.
+      - BUSINESS A specific Business (for example, an organization or a company) is used as reference to a participant. The BUSINESS identifier can be in any format. To make a transaction connected to a specific username or bill number in a Business, the PartySubIdOrType element should be used.
+      - DEVICE A specific device (for example, a POS or ATM) ID connected to a specific business or organization is used as reference to a Party. For referencing a specific device under a specific business or organization, use the PartySubIdOrType element.
+      - ACCOUNT_ID A bank account number or FSP account ID should be used as reference to a participant. The ACCOUNT_ID identifier can be in any format, as formats can greatly differ depending on country and FSP.
+      - IBAN A bank account number or FSP account ID is used as reference to a participant. The IBAN identifier can consist of up to 34 alphanumeric characters and should be entered without whitespace.
+      - ALIAS An alias is used as reference to a participant. The alias should be created in the FSP as an alternative reference to an account owner. Another example of an alias is a username in the FSP system. The ALIAS identifier can be in any format. It is also possible to use the PartySubIdOrType element for identifying an account under an Alias defined by the PartyIdentifier.
+  PartyName:
+    title: PartyName
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Name of the Party. Could be a real name or a nickname.
+  PartySubIdOrType:
+    title: PartySubIdOrType
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Either a sub-identifier of a PartyIdentifier, or a sub-type of the PartyIdType, normally a PersonalIdentifierType.
+  PersonalIdentifierType:
+    title: PersonalIdentifierType
+    type: string
+    enum:
+    - PASSPORT
+    - NATIONAL_REGISTRATION
+    - DRIVING_LICENSE
+    - ALIEN_REGISTRATION
+    - NATIONAL_ID_CARD
+    - EMPLOYER_ID
+    - TAX_ID_NUMBER
+    - SENIOR_CITIZENS_CARD
+    - MARRIAGE_CERTIFICATE 
+    - HEALTH_CARD
+    - VOTERS_ID
+    - UNITED_NATIONS
+    - OTHER_ID
+    description: Below are the allowed values for the enumeration
+      - PASSPORT A passport number is used as reference to a Party.
+      - NATIONAL_REGISTRATION A national registration number is used as reference to a Party.
+      - DRIVING_LICENSE A driving license is used as reference to a Party.
+      - ALIEN_REGISTRATION An alien registration number is used as reference to a Party.
+      - NATIONAL_ID_CARD A national ID card number is used as reference to a Party.
+      - EMPLOYER_ID A tax identification number is used as reference to a Party.
+      - TAX_ID_NUMBER A tax identification number is used as reference to a Party.
+      - SENIOR_CITIZENS_CARD A senior citizens card number is used as reference to a Party.
+      - MARRIAGE_CERTIFICATE A marriage certificate number is used as reference to a Party.
+      - HEALTH_CARD A health card number is used as reference to a Party.
+      - VOTERS_ID A voter’s identification number is used as reference to a Party.
+      - UNITED_NATIONS An UN (United Nations) number is used as reference to a Party.
+      - OTHER_ID Any other type of identification type number is used as reference to a Party.
+  QRCODE:
+    title: QRCODE
+    type: string
+    minLength: 1
+    maxLength: 64
+    description: QR code used as One Time Password.
+  RefundReason:
+    title: RefundReason
+    type: string
+    minLength: 1
+    maxLength: 128
+    description: Reason for the refund.
+  RetriesLeft:
+    title: RetriesLeft
+    $ref: '#/definitions/Integer' 
+    description: RetriesLeft is the number of retries left before the financial transaction is rejected. It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected.
+  TokenCode:
+    title: TokenCode
+    type: string
+    pattern: ^[0-9a-zA-Z]{4,32}$
+    description: The API data type TokenCode is a JSON String between 4 and 32 characters, consisting of digits or upper or lowercase characters from a to z.
+  TransactionInitiator:
+    title: TransactionInitiatorEnum
+    type: string
+    enum:
+    - PAYER
+    - PAYEE
+    description: Below are the allowed values for the enumeration
+      - PAYER Sender of funds is initiating the transaction. The account to send from is either owned by the Payer or is connected to the Payer in some way.
+      - PAYEE Recipient of the funds is initiating the transaction by sending a transaction request. The Payer must approve the transaction, either automatically by a pre-generated OTP or by pre-approval of the Payee, or by manually approving in his or her own Device.
+  TransactionInitiatorType:
+    title: TransactionInitiatorTypeEnum
+    type: string
+    enum:
+    - CONSUMER
+    - AGENT
+    - BUSINESS
+    - DEVICE
+    description: Below are the allowed values for the enumeration
+      - CONSUMER Consumer is the initiator of the transaction.
+      - AGENT Agent is the initiator of the transaction.
+      - BUSINESS Business is the initiator of the transaction.
+      - DEVICE Device is the initiator of the transaction.
+  TransactionRequestState:
+    title: TransactionRequestStateEnum
+    type: string
+    enum:
+    - RECEIVED
+    - PENDING
+    - ACCEPTED
+    - REJECTED
+    description: Below are the allowed values for the enumeration
+      - RECEIVED Payer FSP has received the transaction from the Payee FSP.
+      - PENDING Payer FSP has sent the transaction request to the Payer.
+      - ACCEPTED Payer has approved the transaction.
+      - REJECTED Payer has rejected the transaction.
+  TransactionScenario:
+    title: TransactionScenarioEnum
+    type: string
+    enum:
+    - DEPOSIT
+    - WITHDRAWAL
+    - TRANSFER
+    - PAYMENT
+    - REFUND
+    description: Below are the allowed values for the enumeration
+      - DEPOSIT Used for performing a Cash-In (deposit) transaction. In a normal scenario, electronic funds are transferred from a Business account to a Consumer account, and physical cash is given from the Consumer to the Business User.
+      - WITHDRAWAL Used for performing a Cash-Out (withdrawal) transaction. In a normal scenario, electronic funds are transferred from a Consumer’s account to a Business account, and physical cash is given from the Business User to the Consumer.
+      - TRANSFER Used for performing a P2P (Peer to Peer, or Consumer to Consumer) transaction.
+      - PAYMENT Usually used for performing a transaction from a Consumer to a Merchant or Organization, but could also be for a B2B (Business to Business) payment. The transaction could be online for a purchase in an Internet store, in a physical store where both the Consumer and Business User are present, a bill payment, a donation, and so on.
+      - REFUND Used for performing a refund of transaction. 
+  TransactionState:
+    title: TransactionStateEnum
+    type: string
+    enum:
+    - RECEIVED
+    - PENDING
+    - COMPLETED
+    - REJECTED
+    description: Below are the allowed values for the enumeration
+      - RECEIVED Payee FSP has received the transaction from the Payer FSP.
+      - PENDING Payee FSP has validated the transaction.
+      - COMPLETED Payee FSP has successfully performed the transaction.
+      - REJECTED Payee FSP has failed to perform the transaction.
+  TransactionSubScenario:
+    title: TransactionSubScenario
+    type: string
+    pattern: ^[A-Z_]{1,32}$
+    description: Possible sub-scenario, defined locally within the scheme (UndefinedEnum Type).
+  TransferState:
+    title: TransferStateEnum
+    type: string
+    enum:
+    - RECEIVED
+    - RESERVED
+    - COMMITTED
+    - ABORTED
+    description: Below are the allowed values for the enumeration
+      - RECEIVED Next ledger has received the transfer.
+      - RESERVED Next ledger has reserved the transfer.
+      - COMMITTED Next ledger has successfully performed the transfer.
+      - ABORTED Next ledger has aborted the transfer due a rejection or failure to perform the transfer.
+  UndefinedEnum:
+    title: UndefinedEnum
+    type: string
+    pattern: ^[A-Z_]{1,32}$
+    description: The API data type UndefinedEnum is a JSON String consisting of 1 to 32 uppercase characters including an underscore character (_).
+  U2F:
+    title: U2F
+    type: string
+    minLength: 1
+    maxLength: 64
+    description: U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
+
+  #Complex Types
+  AuthenticationInfo:
+    title: AuthenticationInfo
+    type: object
+    description: Data model for the complex type AuthenticationInfo
+    properties:
+      authentication:
+        $ref: '#/definitions/AuthenticationType'
+        description: Type of authentication.
+      authenticationValue:
+        $ref: '#/definitions/AuthenticationValue'
+        description: Authentication value.
+    required:
+    - authentication
+    - authenticationValue
+
+  AuthenticationValue:
+    title: AuthenticationValue
+    type: object
+    description: Data model for the complex type AuthenticationValue
+    properties:
+      authenticationVal:
+        $ref: '#/definitions/AuthenticationVal'
+        description: Authentication value.
+      counter:
+        $ref: '#/definitions/Counter'
+        description: Sequential counter used for cloning detection. Present only for U2F authentication.
+    required:
+    - authenticationVal
+
+  AuthorizationsPostRequest:
+    title: AuthorizationsPostRequest
+    type: object
+    description: POST /authorizations Request object
+    properties:
+      authenticationType:
+        $ref: '#/definitions/AuthenticationType'
+        description: This value is a valid authentication type from the enumeration AuthenticationType(OTP or QR Code or U2F).
+      retriesLeft:
+        $ref: '#/definitions/RetriesLeft'
+        description: RetriesLeft is the number of retries left before the financial transaction is rejected. It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected.
+      amount:
+        $ref: '#/definitions/Money'
+        description: This is the transaction amount that will be withdrawn from the Payer’s account.
+      transactionId:
+        $ref: '#/definitions/CorrelationId'
+        description: Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. 
+      transactionRequestId:
+        $ref: '#/definitions/CorrelationId'
+        description: The transactionRequestID, received from the POST /transactionRequests service earlier in the process. 
+      quote:
+        $ref: '#/definitions/QuotesIDPutResponse'
+        description: Quotes object
+    required:
+    - authenticationType
+    - retriesLeft
+    - amount
+    - currency
+    - transactionId
+    - transactionRequestId
+    - quote
+
+  AuthorizationsIDPutResponse:
+    title: AuthorizationsIDPutResponse
+    type: object
+    description: PUT /authorizations/{ID} object
+    properties:
+      authenticationInfo:
+        $ref: '#/definitions/AuthenticationInfo'
+        description: OTP or QR Code if entered, otherwise empty.
+      responseType:
+        $ref: '#/definitions/AuthorizationResponse'
+        description: Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.
+    required:
+    - responseType    
+  BulkQuotesPostRequest:
+    title: BulkQuotesPostRequest
+    type: object
+    description: POST /bulkQuotes object
+    properties:
+      bulkQuoteId:
+        $ref: '#/definitions/CorrelationId'
+        description: Common ID between the FSPs for the bulk quote object, decided by the Payer FSP. The ID should be reused for resends of the same bulk quote. A new ID should be generated for each new bulk quote.
+      payer:
+        $ref: '#/definitions/Party'
+        description: Information about the Payer in the proposed financial transaction.
+      geoCode:
+        $ref: '#/definitions/GeoCode'
+        description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Expiration is optional to let the Payee FSP know when a quote no longer needs to be returned.
+      individualQuotes:
+        type: array
+        minItems: 1
+        maxItems: 1000
+        items:
+          $ref: '#/definitions/IndividualQuote'
+        description: List of quotes elements.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - bulkQuoteId
+    - payer
+    - individualQuotes
+  BulkQuotesIDPutResponse:
+    title: BulkQuotesIDPutResponse
+    type: object
+    description: PUT /bulkQuotes/{ID} object
+    properties:
+      individualQuoteResults:
+        type: array
+        maxItems: 1000
+        items:
+          $ref: '#/definitions/IndividualQuoteResult'
+        description: Fees for each individual transaction, if any of them are charged per transaction.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction request.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - expiration
+  BulkTransfersPostRequest:
+    title: BulkTransfersPostRequest
+    type: object
+    description: POST /bulkTransfers object
+    properties:
+      bulkTransferId:
+        $ref: '#/definitions/CorrelationId'
+        description: Common ID between the FSPs and the optional Switch for the bulk transfer object, decided by the Payer FSP. The ID should be reused for resends of the same bulk transfer. A new ID should be generated for each new bulk transfer.
+      bulkQuoteId:
+        $ref: '#/definitions/CorrelationId'
+        description: ID of the related bulk quote.
+      payerFsp:
+        $ref: '#/definitions/FspId'
+        description: Payer FSP identifier.
+      payeeFsp:
+        $ref: '#/definitions/FspId'
+        description: Payee FSP identifier.
+      individualTransfers:
+        type: array
+        minItems: 1
+        maxItems: 1000
+        items:
+          $ref: '#/definitions/IndividualTransfer'
+        description: List of IndividualTransfer elements.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Expiration time of the transfers.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - bulkTransferId
+    - bulkQuoteId
+    - payerFsp
+    - payeeFsp
+    - individualTransfers
+    - expiration
+  BulkTransfersIDPutResponse:
+    title: BulkTransfersIDPutResponse
+    type: object
+    description: PUT /bulkTransfers/{ID} object
+    properties:
+      completedTimestamp:
+        $ref: '#/definitions/DateTime'
+        description: Time and date when the bulk transaction was completed.
+      individualTransferResults:
+        type: array
+        maxItems: 1000
+        items:
+          $ref: '#/definitions/IndividualTransferResult'
+        description: List of IndividualTransferResult elements.
+      bulkTransferState:
+        $ref: '#/definitions/BulkTransferState'
+        description: The state of the bulk transfer.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - bulkTransferState
+  ErrorInformation:
+    title: ErrorInformation
+    type: object
+    description: Data model for the complex type ErrorInformation.
+    properties:
+      errorCode:
+        $ref: '#/definitions/ErrorCode'
+        description: Specific error number.
+      errorDescription:
+        $ref: '#/definitions/ErrorDescription'
+        description: Error description string.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional list of extensions, specific to deployment.
+    required:
+    - errorCode
+    - errorDescription
+  ErrorInformationObject:
+    title: ErrorInformationObject
+    type: object
+    description: Data model for the complex type object that contains ErrorInformation.
+    properties:
+      errorInformation:
+        $ref: '#/definitions/ErrorInformation'
+    required:
+    - errorInformation
+  ErrorInformationResponse:
+    title: ErrorInformationResponse
+    type: object
+    description: Data model for the complex type object that contains an optional element ErrorInformation used along with 4xx and 5xx responses.
+    properties:
+      errorInformation:
+        $ref: '#/definitions/ErrorInformation'
+  Extension:
+    title: Extension
+    type: object
+    description: Data model for the complex type Extension
+    properties:
+      key:
+        $ref: '#/definitions/ExtensionKey'
+        description: Extension key.
+      value:
+        $ref: '#/definitions/ExtensionValue'
+        description: Extension value.
+    required:
+    - key
+    - value
+  ExtensionList:
+    title: ExtensionList
+    type: object
+    description: Data model for the complex type ExtensionList
+    properties:
+      extension:
+        type: array
+        items:
+          $ref: '#/definitions/Extension'
+        minItems: 1
+        maxItems: 16
+        description: Number of Extension elements
+    required:
+    - extension
+  GeoCode:
+    title: GeoCode
+    type: object
+    description: Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.
+    properties:
+      latitude:
+        $ref: '#/definitions/Latitude'
+        description: Latitude of the Party.
+      longitude:
+        $ref: '#/definitions/Longitude'
+        description: Longitude of the   Party.
+    required:
+    - latitude
+    - longitude
+  IndividualQuote:
+    title: IndividualQuote
+    type: object
+    description: Data model for the complex type IndividualQuote.
+    properties:
+      quoteId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies quote message.
+      transactionId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies transaction message.
+      payee:
+        $ref: '#/definitions/Party'
+        description: Information about the Payee in the proposed financial transaction.
+      amountType:
+        $ref: '#/definitions/AmountType'
+        description: SEND for sendAmount, RECEIVE for receiveAmount.
+      amount:
+        $ref: '#/definitions/Money'
+        description: Depending on amountType -
+          If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
+          If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities.
+      fees:
+        $ref: '#/definitions/Money'
+        description: The fees in the transaction.
+          The fees element should be empty if fees should be non-disclosed.
+          The fees element should be non-empty if fees should be disclosed.
+      transactionType:
+        $ref: '#/definitions/TransactionType'
+        description: Type of transaction that the quote is requested for.
+      note:
+        $ref: '#/definitions/Note'
+        description: Memo that will be attached to the transaction.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - quoteId
+    - transactionId
+    - payee
+    - amountType
+    - amount
+    - transactionType
+  IndividualQuoteResult:
+    title: IndividualQuoteResult
+    type: object
+    description: Data model for the complex type IndividualQuoteResult.
+    properties:
+      quoteId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies quote message.
+      payee:
+        $ref: '#/definitions/Party'
+        description: Information about the Payee in the proposed financial transaction.
+      transferAmount:
+        $ref: '#/definitions/Money'
+        description: The amount of Money that the Payer FSP should transfer to the Payee FSP.
+      payeeReceiveAmount:
+        $ref: '#/definitions/Money'
+        description: Amount that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
+      payeeFspFee:
+        $ref: '#/definitions/Money'
+        description: Payee FSP’s part of the transaction fee.
+      payeeFspCommission:
+        $ref: '#/definitions/Money'
+        description: Transaction commission from the Payee FSP
+      ilpPacket:
+        $ref: '#/definitions/IlpPacket'
+        description: The ILP Packet that must be attached to the transfer by the Payer.
+      condition:
+        $ref: '#/definitions/IlpCondition'
+        description: The condition that must be attached to the transfer by the Payer.
+      errorInformation:
+        $ref: '#/definitions/ErrorInformation'
+        description: Error code, category description. Note - payee, transferAmount, payeeReceiveAmount, payeeFspFee, payeeFspCommission, ilpPacket, and condition should not be set if errorInformation is set.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - quoteId
+  IndividualTransfer:
+    title: IndividualTransfer
+    type: object
+    description: Data model for the complex type IndividualTransfer.
+    properties:
+      transferId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies messages related to the same /transfers sequence.
+      transferAmount:
+        $ref: '#/definitions/Money'
+        description: Transaction amount to be sent.
+      ilpPacket:
+        $ref: '#/definitions/IlpPacket'
+        description: ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
+      condition:
+        $ref: '#/definitions/IlpCondition'
+        description: Condition that must be fulfilled to commit the transfer.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transferId
+    - transferAmount
+    - ilpPacket
+    - condition
+  IndividualTransferResult:
+    title: IndividualTransferResult
+    type: object
+    description: Data model for the complex type IndividualTransferResult.
+    properties:
+      transferId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies messages related to the same /transfers sequence.
+      fulfilment:
+        $ref: '#/definitions/IlpFulfilment'
+        description: Fulfilment of the condition specified with the transaction. Note - Either fulfilment or errorInformation should be set, not both.
+      errorInformation:
+        $ref: '#/definitions/ErrorInformation'
+        description: If transfer is REJECTED, error information may be provided. Note - Either fulfilment or errorInformation should be set, not both.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transferId
+  Money:
+    title: Money
+    type: object
+    description: Data model for the complex type Money.
+    properties:
+      currency:
+        $ref: '#/definitions/Currency'
+        description: Currency of the amount.
+      amount:
+        $ref: '#/definitions/Amount'
+        description: Amount of Money.
+    required:
+    - currency
+    - amount
+  ParticipantsTypeIDSubIDPostRequest:
+    title: ParticipantsTypeIDSubIDPostRequest
+    type: object
+    description: POST /participants/{Type}/{ID}/{SubId}, /participants/{Type}/{ID} object
+    properties:
+      fspId:
+        $ref: '#/definitions/FspId'
+        description: FSP Identifier that the Party belongs to.
+      currency:
+        $ref: '#/definitions/Currency'
+        description: Indicate that the provided Currency is supported by the Party.
+    required:
+    - fspId
+  ParticipantsTypeIDPutResponse:
+    title: ParticipantsTypeIDPutResponse
+    type: object
+    description: PUT /participants/{Type}/{ID}/{SubId}, /participants/{Type}/{ID} object
+    properties:
+      fspId:
+        $ref: '#/definitions/FspId'
+        description: FSP Identifier that the Party belongs to.
+  ParticipantsIDPutResponse:
+    title: ParticipantsIDPutResponse
+    type: object
+    description: PUT /participants/{ID} object
+    properties:
+      partyList:
+        type: array
+        items:
+          $ref: '#/definitions/PartyResult'
+        minItems: 1
+        maxItems: 10000
+        description: List of PartyResult elements that were either created or failed to be created.
+      currency:
+        $ref: '#/definitions/Currency'
+        description: Indicate that the provided Currency was set to be supported by each successfully added PartyIdInfo.
+    required:
+    - partyList
+  ParticipantsPostRequest:
+    title: ParticipantsPostRequest
+    type: object
+    description: POST /participants object
+    properties:
+      requestId:
+        $ref: '#/definitions/CorrelationId'
+        description: The ID of the request, decided by the client. Used for identification of the callback from the server.
+      partyList:
+        type: array
+        items:
+          $ref: '#/definitions/PartyIdInfo'
+        minItems: 1
+        maxItems: 10000
+        description: List of PartyIdInfo elements that the client would like to update or create FSP information about.
+      currency:
+        $ref: '#/definitions/Currency'
+        description: Indicate that the provided Currency is supported by each PartyIdInfo in the list.
+    required:
+    - requestId
+    - partyList
+  Party:
+    title: Party
+    type: object
+    description: Data model for the complex type Party.
+    properties:
+      partyIdInfo:
+        $ref: '#/definitions/PartyIdInfo'
+        description: Party Id type, id, sub ID or type, and FSP Id.
+      merchantClassificationCode:
+        $ref: '#/definitions/MerchantClassificationCode'
+        description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
+      name:
+        $ref: '#/definitions/PartyName'
+        description: Display name of the Party, could be a real name or a nick name.
+      personalInfo:
+        $ref: '#/definitions/PartyPersonalInfo'
+        description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
+    required:
+    - partyIdInfo
+  PartyComplexName:
+    title: PartyComplexName
+    type: object
+    description: Data model for the complex type PartyComplexName.
+    properties:
+      firstName:
+        $ref: '#/definitions/FirstName'
+        description: Party’s first name.
+      middleName:
+        $ref: '#/definitions/MiddleName'
+        description: Party’s middle name.
+      lastName:
+        $ref: '#/definitions/LastName'
+        description: Party’s last name.
+  PartyIdInfo:
+    title: PartyIdInfo
+    type: object
+    description: Data model for the complex type PartyIdInfo.
+    properties:
+      partyIdType:
+        $ref: '#/definitions/PartyIdType'
+        description: Type of the identifier.
+      partyIdentifier:
+        $ref: '#/definitions/PartyIdentifier'
+        description: An identifier for the Party.
+      partySubIdOrType:
+        $ref: '#/definitions/PartySubIdOrType'
+        description: A sub-identifier or sub-type for the Party.
+      fspId:
+        $ref: '#/definitions/FspId'
+        description: FSP ID (if known)
+    required:
+    - partyIdType
+    - partyIdentifier
+  PartiesTypeIDPutResponse:
+    title: PartiesTypeIDPutResponse
+    type: object
+    description: PUT /parties/{Type}/{ID} object
+    properties:
+      party:
+        $ref: '#/definitions/Party'
+        description: Information regarding the requested Party.
+    required:
+    - party
+  PartyPersonalInfo:
+    title: PartyPersonalInfo
+    type: object
+    description: Data model for the complex type PartyPersonalInfo.
+    properties:
+      complexName:
+        $ref: '#/definitions/PartyComplexName'
+        description: First, middle and last name for the Party.
+      dateOfBirth:
+        $ref: '#/definitions/DateOfBirth'
+        description: Date of birth for the Party.
+  PartyResult:
+    title: PartyResult
+    type: object
+    description: Data model for the complex type PartyResult.
+    properties:
+      partyId:
+        $ref: '#/definitions/PartyIdInfo'
+        description: Party Id type, id, sub ID or type, and FSP Id.
+      errorInformation:
+        $ref: '#/definitions/ErrorInformation'
+        description: If the Party failed to be added, error information should be provided. Otherwise, this parameter should be empty to indicate success.
+    required:
+      - partyId
+  QuotesPostRequest:
+    title: QuotesPostRequest
+    type: object
+    description: POST /quotes object
+    properties:
+      quoteId:
+        $ref: '#/definitions/CorrelationId'
+        description: Common ID between the FSPs for the quote object, decided by the Payer FSP. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
+      transactionId:
+        $ref: '#/definitions/CorrelationId'
+        description: Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
+      transactionRequestId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies an optional previously-sent transaction request.
+      payee:
+        $ref: '#/definitions/Party'
+        description: Information about the Payee in the proposed financial transaction.
+      payer:
+        $ref: '#/definitions/Party'
+        description: Information about the Payer in the proposed financial transaction.
+      amountType:
+        $ref: '#/definitions/AmountType'
+        description: SEND for send amount, RECEIVE for receive amount.
+      amount:
+        $ref: '#/definitions/Money'
+        description: Depending on amountType. If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
+          If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities.
+      fees:
+        $ref: '#/definitions/Money'
+        description: The fees in the transaction.
+          The fees element should be empty if fees should be non-disclosed.
+          The fees element should be non-empty if fees should be disclosed.
+      transactionType:
+        $ref: '#/definitions/TransactionType'
+        description: Type of transaction for which the quote is requested.
+      geoCode:
+        $ref: '#/definitions/GeoCode'
+        description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
+      note:
+        $ref: '#/definitions/Note'
+        description: A memo that will be attached to the transaction.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Expiration is optional. It can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, and Merchant to know that their request has a time limit.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - quoteId
+    - transactionId
+    - payee
+    - payer
+    - amountType
+    - amount
+    - transactionType
+  QuotesIDPutResponse:
+    title: QuotesIDPutResponse
+    type: object
+    description: PUT /quotes/{ID} object
+    properties:
+      transferAmount:
+        $ref: '#/definitions/Money'
+        description: The amount of Money that the Payer FSP should transfer to the Payee FSP.
+      payeeReceiveAmount:
+        $ref: '#/definitions/Money'
+        description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
+      payeeFspFee:
+        $ref: '#/definitions/Money'
+        description: Payee FSP’s part of the transaction fee.
+      payeeFspCommission:
+        $ref: '#/definitions/Money'
+        description: Transaction commission from the Payee FSP.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.
+      geoCode:
+        $ref: '#/definitions/GeoCode'
+        description: Longitude and Latitude of the Payee. Can be used to detect fraud.
+      ilpPacket:
+        $ref: '#/definitions/IlpPacket'
+        description: The ILP Packet that must be attached to the transfer by the Payer.
+      condition:
+        $ref: '#/definitions/IlpCondition'
+        description: The condition that must be attached to the transfer by the Payer.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transferAmount
+    - expiration
+    - ilpPacket
+    - condition
+  Refund:
+    title: Refund
+    type: object
+    description: Data model for the complex type Refund.
+    properties:
+      originalTransactionId:
+        $ref: '#/definitions/CorrelationId'
+        description: Reference to the original transaction ID that is requested to be refunded.
+      refundReason:
+        $ref: '#/definitions/RefundReason'
+        description: Free text indicating the reason for the refund.
+    required:
+    - originalTransactionId
+  Transaction:
+    title: Transaction
+    type: object
+    description: Data model for the complex type Transaction. The Transaction type is used to carry end-to-end data between the Payer FSP and the Payee FSP in the ILP Packet. Both the transactionId and the quoteId in the data model are decided by the Payer FSP in the POST /quotes.
+    properties:
+      transactionId:
+        $ref: '#/definitions/CorrelationId'
+        description: ID of the transaction, the ID is decided by the Payer FSP during the creation of the quote.
+      quoteId:
+        $ref: '#/definitions/CorrelationId'
+        description: ID of the quote, the ID is decided by the Payer FSP during the creation of the quote.
+      payee:
+        $ref: '#/definitions/Party'
+        description: Information about the Payee in the proposed financial transaction.
+      payer:
+        $ref: '#/definitions/Party'
+        description: Information about the Payer in the proposed financial transaction.
+      amount:
+        $ref: '#/definitions/Money'
+        description: Transaction amount to be sent.
+      transactionType:
+        $ref: '#/definitions/TransactionType'
+        description: Type of the transaction.
+      note:
+        $ref: '#/definitions/Note'
+        description: Memo associated to the transaction, intended to the Payee.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transactionId
+    - quoteId
+    - payee
+    - payer
+    - amount
+    - transactionType
+  TransactionRequestsIDPutResponse:
+    title: TransactionRequestsIDPutResponse
+    type: object
+    description: PUT /transactionRequests/{ID} object
+    properties:
+      transactionId:
+        $ref: '#/definitions/CorrelationId'
+        description: Identifies a related transaction (if a transaction has been created).
+      transactionRequestState:
+        $ref: '#/definitions/TransactionRequestState'
+        description: State of the transaction request.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transactionRequestState
+  TransactionsIDPutResponse:
+    title: TransactionsIDPutResponse
+    type: object
+    description: PUT /transactions/{ID} object
+    properties:
+      completedTimestamp:
+        $ref: '#/definitions/DateTime'
+        description: Time and date when the transaction was completed.
+      transactionState:
+        $ref: '#/definitions/TransactionState'
+        description: State of the transaction.
+      code:
+        $ref: '#/definitions/Code'
+        description: Optional redemption information provided to Payer after transaction has been completed.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transactionState
+  TransactionType:
+    title: TransactionType
+    type: object
+    description: Data model for the complex type TransactionType.
+    properties:
+      scenario:
+        $ref: '#/definitions/TransactionScenario'
+        description: Deposit, withdrawal, refund, …
+      subScenario:
+        $ref: '#/definitions/TransactionSubScenario'
+        description: Possible sub-scenario, defined locally within the scheme.
+      initiator:
+        $ref: '#/definitions/TransactionInitiator'
+        description: Who is initiating the transaction - Payer or Payee
+      initiatorType:
+        $ref: '#/definitions/TransactionInitiatorType'
+        description: Consumer, agent, business, …
+      refundInfo:
+        $ref: '#/definitions/Refund'
+        description: Extra information specific to a refund scenario. Should only be populated if scenario is REFUND
+      balanceOfPayments:
+        $ref: '#/definitions/BalanceOfPayments'
+        description: Balance of Payments code.
+    required:
+    - scenario
+    - initiator
+    - initiatorType
+  TransfersPostRequest:
+    title: TransfersPostRequest
+    type: object
+    description: POST /transfers Request object
+    properties:
+      transferId:
+        $ref: '#/definitions/CorrelationId'
+        description: The common ID between the FSPs and the optional Switch for the transfer object, decided by the Payer FSP. The ID should be reused for resends of the same transfer. A new ID should be generated for each new transfer.
+      payeeFsp:
+        $ref: '#/definitions/FspId'
+        description: Payee FSP in the proposed financial transaction.
+      payerFsp:
+        $ref: '#/definitions/FspId'
+        description: Payer FSP in the proposed financial transaction.
+      amount:
+        $ref: '#/definitions/Money'
+        description: The transfer amount to be sent.
+      ilpPacket:
+        $ref: '#/definitions/IlpPacket'
+        description: The ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
+      condition:
+        $ref: '#/definitions/IlpCondition'
+        description: The condition that must be fulfilled to commit the transfer.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Expiration can be set to get a quick failure expiration of the transfer. The transfer should be rolled back if no fulfilment is delivered before this time.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transferId
+    - payeeFsp
+    - payerFsp
+    - amount
+    - ilpPacket
+    - condition
+    - expiration
+  TransactionRequestsPostRequest:
+    title: TransactionRequestsPostRequest
+    type: object
+    description: POST /transactionRequests object
+    properties:
+      transactionRequestId:
+        $ref: '#/definitions/CorrelationId'
+        description: Common ID between the FSPs for the transaction request object, decided by the Payee FSP. The ID should be reused for resends of the same transaction request. A new ID should be generated for each new transaction request.
+      payee:
+        $ref: '#/definitions/Party'
+        description: Information about the Payee in the proposed financial transaction.
+      payer:
+        $ref: '#/definitions/PartyIdInfo'
+        description: Information about the Payer type, id, sub-type/id, FSP Id in the proposed financial transaction.
+      amount:
+        $ref: '#/definitions/Money'
+        description: Requested amount to be transferred from the Payer to Payee.
+      transactionType:
+        $ref: '#/definitions/TransactionType'
+        description: Type of transaction.
+      note:
+        $ref: '#/definitions/Note'
+        description: Reason for the transaction request, intended to the Payer.
+      geoCode:
+        $ref: '#/definitions/GeoCode'
+        description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
+      authenticationType:
+        $ref: '#/definitions/AuthenticationType'
+        description: OTP or QR Code, otherwise empty.
+      expiration:
+        $ref: '#/definitions/DateTime'
+        description: Can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, Merchant to know that their request has a time limit.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transactionRequestId
+    - payee
+    - payer
+    - amount
+    - transactionType
+  TransfersIDPutResponse:
+    title: TransfersIDPutResponse
+    type: object
+    description: PUT /transfers/{ID} object
+    properties:
+      fulfilment:
+        $ref: '#/definitions/IlpFulfilment'
+        description: Fulfilment of the condition specified with the transaction. Mandatory if transfer has completed successfully.
+      completedTimestamp:
+        $ref: '#/definitions/DateTime'
+        description: Time and date when the transaction was completed.
+      transferState:
+        $ref: '#/definitions/TransferState'
+        description: State of the transfer.
+      extensionList:
+        $ref: '#/definitions/ExtensionList'
+        description: Optional extension, specific to deployment.
+    required:
+    - transferState
+
+responses:
+  Response200:
+    description: OK
+  Response202:
+    description: Accepted
+  ErrorResponse400:
+    description: Bad Request - The application cannot process the request; for example, due to malformed syntax or the payload exceeded size restrictions.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse401:
+    description: Unauthorized - The request requires authentication in order to be processed.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse403:
+    description: Forbidden - The request was denied and will be denied in the future.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse404:
+    description: Not Found - The resource specified in the URI was not found.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse405:
+    description: Method Not Allowed - An unsupported HTTP method for the request was used.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse406:
+    description: Not acceptable - The server is not capable of generating content according to the Accept headers sent in the request. Used in the API to indicate that the server does not support the version that the client is requesting.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse501:
+    description: Not Implemented - The server does not support the requested service. The client should not retry.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+  ErrorResponse503:
+    description: Service Unavailable - The server is currently unavailable to accept any new service requests. This should be a temporary state, and the client should retry within a reasonable time frame.
+    schema:
+      $ref: '#/definitions/ErrorInformationResponse'
+    headers:
+      Content-Length:
+        description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.
+        type: integer
+      Content-Type:
+        description: The Content-Type header indicates the specific version of the API used to send the payload body.
+        type: string
+
+parameters:
+  Accept:
+    name: Accept
+    in: header
+    required: true
+    type: string
+    description: The Accept header field indicates the version of the API the client would like the server to use.
+  Content-Length:
+    name: Content-Length
+    in: header
+    required: false
+    type: integer
+    description: The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body. Note - The API supports a maximum size of 5242880 bytes (5 Megabytes)
+  Content-Type:
+    name: Content-Type
+    in: header
+    type: string
+    required: true
+    description: The Content-Type header indicates the specific version of the API used to send the payload body.
+  Date:
+    name: Date
+    in: header
+    type: string
+    required: true
+    description: The Date header field indicates the date when the request was sent.
+  X-Forwarded-For:
+    name: X-Forwarded-For
+    in: header
+    type: string
+    required: false
+    description: The X-Forwarded-For header field is an unofficially accepted standard used for informational purposes of the originating client IP address, as a request might pass multiple proxies, firewalls, and so on. Multiple X-Forwarded-For values as in the example shown here should be expected and supported by implementers of the API.
+      Note - An alternative to X-Forwarded-For is defined in RFC 7239. However, to this point RFC 7239 is less-used and supported than X-Forwarded-For.
+  FSPIOP-Source:
+    name: FSPIOP-Source
+    in: header
+    type: string
+    required: true
+    description: The FSPIOP-Source header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. The field should be set by the original sender of the request. Required for routing and signature verification (see header field FSPIOP-Signature). 
+  FSPIOP-Destination:
+    name: FSPIOP-Destination
+    in: header
+    type: string
+    required: false
+    description: The FSPIOP-Destination header field is a non-HTTP standard field used by the API for HTTP header based routing of requests and responses to the destination. The field should be set by the original sender of the request (if known), so that any entities between the client and the server do not need to parse the payload for routing purposes.
+  FSPIOP-Encryption:
+    name: FSPIOP-Encryption
+    in: header
+    type: string
+    required: false
+    description: The FSPIOP-Encryption header field is a non-HTTP standard field used by the API for applying end-to-end encryption of the request.
+  FSPIOP-Signature:
+    name: FSPIOP-Signature
+    in: header
+    type: string
+    required: false
+    description: The FSPIOP-Signature header field is a non-HTTP standard field used by the API for applying an end-to-end request signature.
+  FSPIOP-URI:
+    name: FSPIOP-URI
+    in: header
+    type: string
+    required: false
+    description: The FSPIOP-URI header field is a non-HTTP standard field used by the API for signature verification, should contain the service URI. Required if signature verification is used, for more information see API Signature document.
+  FSPIOP-HTTP-Method:
+    name: FSPIOP-HTTP-Method
+    in: header
+    type: string
+    required: false
+    description: The FSPIOP-HTTP-Method header field is a non-HTTP standard field used by the API for signature verification, should contain the service HTTP method. Required if signature verification is used, for more information see API Signature document.
+  ID:
+    name: ID
+    in: path
+    required: true
+    type: string
+  Type:
+    name: Type
+    in: path
+    required: true
+    type: string
+  SubId:
+    name: SubId
+    in: path
+    required: true
+    type: string

--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
@@ -2019,7 +2019,7 @@ components:
       oneOf:
         - $ref: '#/components/schemas/OtpValue'
         - $ref: '#/components/schemas/QRCODE'
-        - $ref: '#/components/schemas/U2FResponse'
+        - $ref: '#/components/schemas/U2FPinValue'
       description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
 
     AuthorizationResponse:
@@ -2598,22 +2598,22 @@ components:
       pattern: ^[A-Z_]{1,32}$
       description: The API data type UndefinedEnum is a JSON String consisting of 1 to 32 uppercase characters including an underscore character (_).
     
-    U2FResponse:
-      title: U2FResponse
+    U2FPinValue:
+      title: U2FPinValue
       type: object
       description: U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
       properties:
-        challenge:
-          $ref: '#/components/schemas/U2FChallenge'
+        pinValue:
+          $ref: '#/components/schemas/U2FPIN'
           description: U2F challenge-response.
         counter:
           $ref: '#/components/schemas/Counter'
           description: Sequential counter used for cloning detection. Present only for U2F authentication.
       required:
-      - challenge
+      - pinValue
       - counter
-    U2FChallenge:
-      title: U2FChallenge
+    U2FPIN:
+      title: U2FPIN
       type: string
       pattern: ^\S{1,64}$
       minLength: 1

--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
@@ -1,0 +1,3965 @@
+openapi: "3.0.2"
+info:
+  version: "1.1" 
+  title: Open API for FSP Interoperability (FSPIOP) (Implementation Friendly Version) 
+  description: Based on [API Definition version 1.0](https://github.com/mojaloop/mojaloop-specification/blob/develop/API%20Definition%20v1.0.pdf). 
+    
+    
+    **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP header.
+  license:
+    name: Open API for FSP Interoperability (FSPIOP) (Implementation Friendly Version)
+    url: https://github.com/mojaloop/mojaloop-specification/blob/develop/LICENSE.md
+servers:
+  - url: '{protocol}://hostname:<port>/switch/'
+    variables:
+      protocol:
+        enum:
+          - http
+          - https
+        default: https
+
+paths:
+  #Participants
+  /participants/{Type}/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/Type'
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    post:
+      description: The HTTP request `POST /participants/{Type}/{ID}` (or `POST /participants/{Type}/{ID}/{SubId}`) is used to create information in the server regarding the provided identity, defined by `{Type}`, `{ID}`, and optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789` or `POST /participants/BUSINESS/shoecompany/employee1`).
+      summary: Create participant information
+      tags:
+      - participants
+      operationId: ParticipantsByIDAndType
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Participant information to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantsTypeIDSubIDPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    get:
+      description: The HTTP request `GET /participants/{Type}/{ID}` (or `GET /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`, is located (for example, `GET /participants/MSISDN/123456789`, or `GET /participants/BUSINESS/shoecompany/employee1`). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      summary: Look up participant information
+      tags:
+      - participants
+      operationId: ParticipantsByTypeAndID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /participants/{Type}/{ID}` (or `PUT /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      summary: Return participant information
+      tags:
+      - participants
+      operationId: ParticipantsByTypeAndID3
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Participant information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantsTypeIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    delete:
+      description: The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE /participants/{Type}/{ID}/{SubId}`) is used to delete information in the server regarding the provided identity, defined by `{Type}` and `{ID}`) (for example, `DELETE /participants/MSISDN/123456789`), and optionally `{SubId}`. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request `DELETE /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      
+      
+        **Note:** The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+      summary: Delete participant information
+      tags:
+      - participants
+      operationId: ParticipantsByTypeAndID2
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /participants/{Type}/{ID}/error:
+    put:
+      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback `PUT /participants/{Type}/{ID}/error` (or `PUT /participants/{Type}/{ID}/{SubId}/error`) is used.
+      summary: Return participant information error
+      tags:
+      - participants
+      operationId: ParticipantsErrorByTypeAndID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /participants/{Type}/{ID}/{SubId}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/Type'
+    - $ref: '#/components/parameters/ID'
+    - $ref: '#/components/parameters/SubId'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    post:
+      description: The HTTP request `POST /participants/{Type}/{ID}` (or `POST /participants/{Type}/{ID}/{SubId}`) is used to create information in the server regarding the provided identity, defined by `{Type}`, `{ID}`, and optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789` or `POST /participants/BUSINESS/shoecompany/employee1`).
+      summary: Create participant information
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndIDPost
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Participant information to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantsTypeIDSubIDPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    get:
+      description: The HTTP request `GET /participants/{Type}/{ID}` (or `GET /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`, is located (for example, `GET /participants/MSISDN/123456789`, or `GET /participants/BUSINESS/shoecompany/employee1`). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      summary: Look up participant information
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /participants/{Type}/{ID}` (or `PUT /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      summary: Return participant information
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndID3
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Participant information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantsTypeIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    delete:
+      description: The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE /participants/{Type}/{ID}/{SubId}`) is used to delete information in the server regarding the provided identity, defined by `{Type}` and `{ID}`) (for example, `DELETE /participants/MSISDN/123456789`), and optionally `{SubId}`. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request `DELETE /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      
+      
+        **Note:** The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+      summary: Delete participant information
+      tags:
+      - participants
+      operationId: ParticipantsSubIdByTypeAndID2
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /participants/{Type}/{ID}/{SubId}/error:
+    put:
+      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback `PUT /participants/{Type}/{ID}/error` (or `PUT /participants/{Type}/{ID}/{SubId}/error`) is used.
+      summary: Return participant information error
+      tags:
+      - participants
+      operationId: ParticipantsSubIdErrorByTypeAndID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/SubId'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /participants:
+    post:
+      description: The HTTP request `POST /participants` is used to create information in the server regarding the provided list of identities. This request should be used for bulk creation of FSP information for more than one Party. The optional currency parameter should indicate that each provided Party supports the currency.
+      summary: Create bulk participant information
+      tags:
+      - participants
+      operationId: Participants1
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Participant information to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantsPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /participants/{ID}:
+    put:
+      description: The callback `PUT /participants/{ID}` is used to inform the client of the result of the creation of the provided list of identities.
+      summary: Return bulk participant information
+      tags:
+      - participants
+      operationId: putParticipantsByID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Participant information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ParticipantsIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /participants/{ID}/error: 
+    put:
+      description: If there is an error during FSP information creation in the server, the error callback `PUT /participants/{ID}/error` is used. The `{ID}` in the URI should contain the requestId that was used for the creation of the participant information.
+      summary: Return bulk participant information error
+      tags:
+      - participants
+      operationId: ParticipantsByIDAndError
+      parameters:
+      #Path
+        - $ref: '#/components/parameters/ID'
+      #Headers
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'          
+          
+  #Parties
+  /parties/{Type}/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/Type'
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET /parties/BUSINESS/shoecompany/employee1`).
+      summary: Look up party information
+      tags:
+      - parties
+      operationId: PartiesByTypeAndID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the Party information lookup.
+      summary: Return party information
+      tags:
+      - parties
+      operationId: PartiesByTypeAndID2
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Party information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /parties/{Type}/{ID}/error:
+    put:
+      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubI}/error`) is used.
+      summary: Return party information error
+      tags:
+      - parties
+      operationId: PartiesErrorByTypeAndID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /parties/{Type}/{ID}/{SubId}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/Type'
+    - $ref: '#/components/parameters/ID'
+    - $ref: '#/components/parameters/SubId'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET /parties/BUSINESS/shoecompany/employee1`).
+      summary: Look up party information
+      tags:
+      - parties
+      operationId: PartiesSubIdByTypeAndID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the Party information lookup.
+      summary: Return party information
+      tags:
+      - parties
+      operationId: PartiesSubIdByTypeAndIDPut
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Party information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /parties/{Type}/{ID}/{SubId}/error:
+    put:
+      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubId}/error`) is used.
+      summary: Return party information error
+      tags:
+      - parties
+      operationId: PartiesSubIdErrorByTypeAndID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/SubId'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+          
+  #Transaction requests        
+  /transactionRequests:
+    post:
+      description: The HTTP request `POST /transactionRequests` is used to request the creation of a transaction request for the provided financial transaction in the server.
+      summary: Perform transaction request
+      tags:
+      - transactionRequests
+      operationId: TransactionRequests
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Transaction request to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransactionRequestsPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /transactionRequests/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /transactionRequests/{ID}` is used to get information regarding a transaction request created or requested earlier. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request.
+      summary: Retrieve transaction request information
+      tags:
+      - transactionRequests
+      operationId: TransactionRequestsByID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /transactionRequests/{ID}` is used to inform the client of a requested or created transaction request. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request, or the `{ID}` that was used in the `GET /transactionRequests/{ID}`.
+      summary: Return transaction request information
+      tags:
+      - transactionRequests
+      operationId: TransactionRequestsByIDPut
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Transaction request information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransactionRequestsIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /transactionRequests/{ID}/error:
+    put:
+      description: If the server is unable to find or create a transaction request, or another processing error occurs, the error callback `PUT /transactionRequests/{ID}/error` is used. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request, or the `{ID}` that was used in the `GET /transactionRequests/{ID}`.
+      summary: Return transaction request information error
+      tags:
+      - transactionRequests
+      operationId: TransactionRequestsErrorByID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'          
+          
+  #Quotes
+  /quotes:
+    post:
+      description: The HTTP request `POST /quotes` is used to request the creation of a quote for the provided financial transaction in the server.
+      summary: Calculate quote
+      tags:
+      - quotes
+      operationId: Quotes
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the quote to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuotesPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'  
+  /quotes/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /quotes/{ID}` is used to get information regarding a quote created or requested earlier. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote.
+      summary: Retrieve quote information
+      tags:
+      - quotes
+      operationId: QuotesByID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /quotes/{ID}` is used to inform the client of a requested or created quote. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote, or the `{ID}` that was used in the `GET /quotes/{ID}` request.
+      summary: Return quote information
+      tags:
+      - quotes
+      operationId: QuotesByID1
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Quote information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuotesIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /quotes/{ID}/error:
+    put:
+      description: If the server is unable to find or create a quote, or some other processing error occurs, the error callback `PUT /quotes/{ID}/error` is used. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote, or the `{ID}` that was used in the `GET /quotes/{ID}` request.
+      summary: Return quote information error
+      tags:
+      - quotes
+      operationId: QuotesByIDAndError
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'          
+          
+  #Authorizations
+  /authorizations:
+    post:
+      description: The HTTP request `POST /authorizations` is used to request the Payer to enter the applicable credentials in the PISP system.
+      summary: Perform PISP authorization
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDPost
+      parameters:
+      #Headers	  
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Perform authorization
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizationsPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  /authorizations/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /authorizations/{ID}` is used to request the Payer to enter the applicable credentials in the Payee FSP system. The `{ID}` in the URI should contain the `transactionRequestID`, received from the `POST /transactionRequests` service earlier in the process. This request requires a query string to be included in the URI, with the following key-value pairs*:*
+      
+      
+        - `authenticationType={Type}`, where `{Type}` value is a valid authentication type from the enumeration `AuthenticationType`.
+        
+        
+        - `retriesLeft=={NrOfRetries}`, where `{NrOfRetries}` is the number of retries left before the financial transaction is rejected. `{NrOfRetries}` must be expressed in the form of the data type `Integer`. `retriesLeft=1` means that this is the last retry before the financial transaction is rejected.
+        
+        
+        - `amount={Amount}`, where `{Amount}` is the transaction amount that will be withdrawn from the Payer’s account. `{Amount}` must be expressed in the form of the data type `Amount`.
+        
+        
+        - `currency={Currency}`, where `{Currency}` is the transaction currency for the amount that will be withdrawn from the Payer’s account. The `{Currency}` value must be expressed in the form of the enumeration `CurrencyCode`.
+        
+        
+        The following is an example URI containing all the required key-value pairs in the query string*:*
+        
+        
+        `GET /authorization/3d492671-b7af-4f3f-88de-76169b1bdf88?authenticationType=OTP&retriesLeft=2&amount=102&currency=USD`
+      summary: Perform authorization
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDGet
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /authorizations/{ID}` is used to inform the client of the result of a previously-requested authorization. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /authorizations/{ID}` request.
+      summary: Return authorization result
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDPut
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Authorization result returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizationsIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /authorizations/{ID}/error:
+    put:
+      description: If the server is unable to find the transaction request, or another processing error occurs, the error callback `PUT /authorizations/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /authorizations/{ID}`.
+      summary: Return authorization error
+      tags:
+      - authorizations
+      operationId: AuthorizationsByIDAndError
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+          
+  #Transfers
+  /transfers:
+    post:
+      description: The HTTP request `POST /transfers` is used to request the creation of a transfer for the next ledger, and a financial transaction for the Payee FSP.
+      summary: Perform transfer
+      tags:
+      - transfers
+      operationId: transfers
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the transfer to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransfersPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'  
+  /transfers/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /transfers/{ID}` is used to get information regarding a transfer created or requested earlier. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer.
+      summary: Retrieve transfer information
+      tags:
+      - transfers
+      operationId: TransfersByIDGet
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /transfers/{ID}` is used to inform the client of a requested or created transfer. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer, or the `{ID}` that was used in the `GET /transfers/{ID}` request.
+      summary: Return transfer information
+      tags:
+      - transfers
+      operationId: TransfersByIDPut
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Transfer information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransfersIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /transfers/{ID}/error:
+    put:
+      description: If the server is unable to find or create a transfer, or another processing error occurs, the error callback `PUT /transfers/{ID}/error` is used. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer, or the `{ID}` that was used in the `GET /transfers/{ID}`.
+      summary: Return transfer information error
+      tags:
+      - transfers
+      operationId: TransfersByIDAndError
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+  #Transactions
+  /transactions/{ID}:
+    parameters:
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /transactions/{ID}` is used to get transaction information regarding a financial transaction created earlier. The `{ID}` in the URI should contain the `transactionId` that was used for the creation of the quote, as the transaction is created as part of another process (the transfer process).
+      summary: Retrieve transaction information
+      tags:
+      - transactions
+      operationId: TransactionsByID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /transactions/{ID}` is used to inform the client of a requested transaction. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /transactions/{ID}` request.
+      summary: Return transaction information
+      tags:
+      - transactions
+      operationId: TransactionsByID1
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Transaction information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TransactionsIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /transactions/{ID}/error:
+    put:
+      description: If the server is unable to find or create a transaction, or another processing error occurs, the error callback `PUT /transactions/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /transactions/{ID}` request.
+      summary: Return transaction information error
+      tags:
+      - transactions
+      operationId: TransactionsErrorByID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+          
+  #Bulk Quotes
+  /bulkQuotes:
+    post:
+      description: The HTTP request `POST /bulkQuotes` is used to request the creation of a bulk quote for the provided financial transactions in the server.
+      summary: Calculate bulk quote
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotes
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the bulk quote to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkQuotesPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /bulkQuotes/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /bulkQuotes/{ID}` is used to get information regarding a bulk quote created or requested earlier. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote.
+      summary: Retrieve bulk quote information
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotesByID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /bulkQuotes/{ID}` is used to inform the client of a requested or created bulk quote. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote, or the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
+      summary: Return bulk quote information
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotesByID1
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Bulk quote information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkQuotesIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /bulkQuotes/{ID}/error:
+    put:
+      description: If the server is unable to find or create a bulk quote, or another processing error occurs, the error callback `PUT /bulkQuotes/{ID}/error` is used. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote, or the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
+      summary: Return bulk quote information error
+      tags:
+      - bulkQuotes
+      operationId: BulkQuotesErrorByID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'          
+          
+  #Bulk transfers
+  /bulkTransfers:
+    post:
+      description: The HTTP request `POST /bulkTransfers` is used to request the creation of a bulk transfer in the server.
+      summary: Perform bulk transfer
+      tags:
+      - bulkTransfers
+      operationId: BulkTransfers
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the bulk transfer to be created.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkTransfersPostRequest'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /bulkTransfers/{ID}:
+    parameters:
+    #Path
+    - $ref: '#/components/parameters/ID'
+    #Headers
+    - $ref: '#/components/parameters/Content-Type'
+    - $ref: '#/components/parameters/Date'
+    - $ref: '#/components/parameters/X-Forwarded-For'
+    - $ref: '#/components/parameters/FSPIOP-Source'
+    - $ref: '#/components/parameters/FSPIOP-Destination'
+    - $ref: '#/components/parameters/FSPIOP-Encryption'
+    - $ref: '#/components/parameters/FSPIOP-Signature'
+    - $ref: '#/components/parameters/FSPIOP-URI'
+    - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+    get:
+      description: The HTTP request `GET /bulkTransfers/{ID}` is used to get information regarding a bulk transfer created or requested earlier. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer.
+      summary: Retrieve bulk transfer information
+      tags:
+      - bulkTransfers
+      operationId: BulkTransferByID
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Accept'
+      responses:
+        202:
+          $ref: '#/components/responses/202'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+    put:
+      description: The callback `PUT /bulkTransfers/{ID}` is used to inform the client of a requested or created bulk transfer. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET /bulkTransfers/{ID}` request.
+      summary: Return bulk transfer information
+      tags:
+      - bulkTransfers
+      operationId: BulkTransfersByIDPut
+      parameters:
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      requestBody:
+        description: Bulk transfer information returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkTransfersIDPutResponse'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+  /bulkTransfers/{ID}/error:
+    put:
+      description: If the server is unable to find or create a bulk transfer, or another processing error occurs, the error callback `PUT /bulkTransfers/{ID}/error` is used. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET /bulkTransfers/{ID}` request.
+      summary: Return bulk transfer information error
+      tags:
+      - bulkTransfers
+      operationId: BulkTransfersErrorByID
+      parameters:
+      #Path
+      - $ref: '#/components/parameters/ID'
+      #Headers
+      - $ref: '#/components/parameters/Content-Length'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      requestBody:
+        description: Details of the error returned.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorInformationObject'
+      responses:
+        200:
+          $ref: '#/components/responses/200'
+        400:
+          $ref: '#/components/responses/400'
+        401:
+          $ref: '#/components/responses/401'
+        403:
+          $ref: '#/components/responses/403'
+        404:
+          $ref: '#/components/responses/404'
+        405:
+          $ref: '#/components/responses/405'
+        406:
+          $ref: '#/components/responses/406'
+        501:
+          $ref: '#/components/responses/501'
+        503:
+          $ref: '#/components/responses/503'
+
+components:
+  schemas:
+  #Element definitions
+    Amount:
+      title: Amount
+      type: string
+      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+      description: The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.
+    AmountType:
+      title: AmountType
+      type: string
+      enum:
+      - SEND
+      - RECEIVE
+      description: Below are the allowed values for the enumeration AmountType.
+      
+        - SEND - Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees.
+        
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver exclusive of any fees.    
+    AuthenticationType:
+      title: AuthenticationType
+      type: string
+      enum:
+      - OTP
+      - QRCODE
+      - U2F
+      description: Below are the allowed values for the enumeration AuthenticationType.
+      
+        - OTP - One-time password generated by the Payer FSP.
+        
+        - QRCODE - QR code used as One Time Password.
+
+        - U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
+    
+    AuthenticationValue:
+      title: AuthenticationValue
+      oneOf:
+        - $ref: '#/components/schemas/OtpValue'
+        - $ref: '#/components/schemas/QRCODE'
+        - $ref: '#/components/schemas/U2FResponse'
+      description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
+
+    AuthorizationResponse:
+      title: AuthorizationResponse
+      type: string
+      enum:
+      - ENTERED
+      - REJECTED
+      - RESEND
+      description: Below are the allowed values for the enumeration.
+      
+        - ENTERED - Consumer entered the authentication value.
+        
+        - REJECTED - Consumer rejected the transaction.
+        
+        - RESEND - Consumer requested to resend the authentication value.
+    BalanceOfPayments:
+      title: BalanceOfPayments
+      type: string
+      pattern: ^[1-9]\d{2}$
+      description: (BopCode) The API data type [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String of 3 characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed.
+    BinaryString:
+      type: string
+      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+      description: The API data type BinaryString is a JSON String. The string is a base64url  encoding of a string of raw bytes, where padding (character ‘=’) is added at the end of the data if needed to ensure that the string is a multiple of 4 characters. The length restriction indicates the allowed number of characters.
+    BinaryString32:
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      description: The API data type BinaryString32 is a fixed size version of the API data type BinaryString, where the raw underlying data is always of 32 bytes. The data type BinaryString32 should not use a padding character as the size of the underlying data is fixed.
+    BulkTransferState:
+      title: BulkTransactionState
+      type: string
+      enum:
+      - RECEIVED
+      - PENDING
+      - ACCEPTED
+      - PROCESSING
+      - COMPLETED
+      - REJECTED
+      description: Below are the allowed values for the enumeration.
+      
+        - RECEIVED - Payee FSP has received the bulk transfer from the Payer FSP.
+        
+        - PENDING - Payee FSP has validated the bulk transfer.
+        
+        - ACCEPTED - Payee FSP has accepted to process the bulk transfer.
+        
+        - PROCESSING - Payee FSP has started to transfer fund to the Payees.
+        
+        - COMPLETED - Payee FSP has completed transfer of funds to the Payees.
+        
+        - REJECTED - Payee FSP has rejected to process the bulk transfer.
+    Code:
+      title: Code
+      type: string
+      pattern: ^[0-9a-zA-Z]{4,32}$
+      description: Any code/token returned by the Payee FSP (TokenCode Type).
+    CorrelationId:
+      title: CorrelationId
+      type: string
+      pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+      description: Identifier that correlates all messages of the same sequence. The API data type UUID (Universally Unique Identifier) is a JSON String in canonical format, conforming to [RFC 4122](https://tools.ietf.org/html/rfc4122), that is restricted by a regular expression for interoperability reasons. A UUID is always 36 characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+    Currency:
+      title: Currency
+      description: The currency codes defined in [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter alphabetic codes are used as the standard naming representation for currencies.
+      type: string
+      minLength: 3
+      maxLength: 3
+      enum:
+      - AED
+      - AFN
+      - ALL
+      - AMD
+      - ANG
+      - AOA
+      - ARS
+      - AUD
+      - AWG
+      - AZN
+      - BAM
+      - BBD
+      - BDT
+      - BGN
+      - BHD
+      - BIF
+      - BMD
+      - BND
+      - BOB
+      - BRL
+      - BSD
+      - BTN
+      - BWP
+      - BYN
+      - BZD
+      - CAD
+      - CDF
+      - CHF
+      - CLP
+      - CNY
+      - COP
+      - CRC
+      - CUC
+      - CUP
+      - CVE
+      - CZK
+      - DJF
+      - DKK
+      - DOP
+      - DZD
+      - EGP
+      - ERN
+      - ETB
+      - EUR
+      - FJD
+      - FKP
+      - GBP
+      - GEL
+      - GGP
+      - GHS
+      - GIP
+      - GMD
+      - GNF
+      - GTQ
+      - GYD
+      - HKD
+      - HNL
+      - HRK
+      - HTG
+      - HUF
+      - IDR
+      - ILS
+      - IMP
+      - INR
+      - IQD
+      - IRR
+      - ISK
+      - JEP
+      - JMD
+      - JOD
+      - JPY
+      - KES
+      - KGS
+      - KHR
+      - KMF
+      - KPW
+      - KRW
+      - KWD
+      - KYD
+      - KZT
+      - LAK
+      - LBP
+      - LKR
+      - LRD
+      - LSL
+      - LYD
+      - MAD
+      - MDL
+      - MGA
+      - MKD
+      - MMK
+      - MNT
+      - MOP
+      - MRO
+      - MUR
+      - MVR
+      - MWK
+      - MXN
+      - MYR
+      - MZN
+      - NAD
+      - NGN
+      - NIO
+      - NOK
+      - NPR
+      - NZD
+      - OMR
+      - PAB
+      - PEN
+      - PGK
+      - PHP
+      - PKR
+      - PLN
+      - PYG
+      - QAR
+      - RON
+      - RSD
+      - RUB
+      - RWF
+      - SAR
+      - SBD
+      - SCR
+      - SDG
+      - SEK
+      - SGD
+      - SHP
+      - SLL
+      - SOS
+      - SPL
+      - SRD
+      - STD
+      - SVC
+      - SYP
+      - SZL
+      - THB
+      - TJS
+      - TMT
+      - TND
+      - TOP
+      - TRY
+      - TTD
+      - TVD
+      - TWD
+      - TZS
+      - UAH
+      - UGX
+      - USD
+      - UYU
+      - UZS
+      - VEF
+      - VND
+      - VUV
+      - WST
+      - XAF
+      - XCD
+      - XDR
+      - XOF
+      - XPF
+      - YER
+      - ZAR
+      - ZMW
+      - ZWD
+    Date:
+      title: Date
+      type: string
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: The API data type Date is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+        This format, as specified in ISO 8601, contains a date only. A more readable version of the format is yyyy-MM-dd. Examples are "1982-05-23", "1987-08-05”.
+    DateOfBirth:
+      title: DateofBirth (type Date)
+      type: string
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: Date of Birth of the Party.
+    DateTime:
+      title: DateTime
+      type: string
+      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+        The format is according to [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed in a combined date, time and time zone format. A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z indicates Zulu time zone, same as UTC).
+    ErrorCode:
+      title: ErrorCode
+      type: string
+      pattern: ^[1-9]\d{3}$
+      description: The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represent the specific error.
+    ErrorDescription:
+      title: ErrorDescription
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Error description string.
+    ExtensionKey:
+      title: ExtensionKey
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: Extension key.
+    ExtensionValue:
+      title: ExtensionValue
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Extension value.
+    FirstName:
+      title: FirstName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: First name of the Party (Name Type).
+    FspId:
+      title: FspId
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: FSP identifier.
+    IlpCondition:
+      title: IlpCondition
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Condition that must be attached to the transfer by the Payer.
+    IlpFulfilment:
+      title: IlpFulfilment
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Fulfilment that must be attached to the transfer by the Payee.
+    IlpPacket:
+      title: IlpPacket
+      type: string
+      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+      minLength: 1
+      maxLength: 32768
+      description: Information for recipient (transport layer information).
+    Integer:
+      title: Integer
+      type: string
+      pattern: ^[1-9]\d*$
+      description: The API data type Integer is a JSON String consisting of digits only. Negative numbers and leading zeroes are not allowed. The data type is always limited to a specific number of digits.
+    LastName:
+      title: LastName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: Last name of the Party (Name Type).
+    Latitude:
+      title: Latitude
+      type: string
+      pattern: ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: The API data type Latitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+    Longitude:
+      title: Longitude
+      type: string
+      pattern: ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: The API data type Longitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
+    MerchantClassificationCode:
+      title: MerchantClassificationCode
+      type: string
+      pattern: ^[\d]{1,4}$
+      description: A limited set of pre-defined numbers. This list would be a limited set of numbers identifying a set of popular merchant types like School Fees, Pubs and Restaurants, Groceries, etc.
+    MiddleName:
+      title: MiddleName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: Middle name of the Party (Name Type).
+    Name:
+      title: Name
+      type: string
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally not used in a name.
+        
+        
+        Regular Expression - The regular expression for restricting the Name type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,) and space characters ( ).
+        
+        
+        **Note:** In some programming languages, Unicode support must be specifically enabled. For example, if Java is used, the flag UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+    Note:
+      title: Note
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Memo assigned to transaction.
+    OtpValue:
+      title: OtpValue
+      type: string
+      pattern: ^\d{3,10}$
+      description: The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. Negative numbers are not allowed. One or more leading zeros are allowed.
+    PartyIdentifier:
+      title: PartyIdentifier
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Identifier of the Party.
+    PartyIdType:
+      title: PartyIdType
+      type: string
+      enum:
+      - MSISDN
+      - EMAIL
+      - PERSONAL_ID
+      - BUSINESS
+      - DEVICE
+      - ACCOUNT_ID
+      - IBAN
+      - ALIAS
+      description: Below are the allowed values for the enumeration.
+      
+        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the [ITU-T E.164 standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix.
+        
+        - EMAIL - An email is used as reference to a participant. The format of the email should be according to the informational [RFC 3696](https://tools.ietf.org/html/rfc3696).
+        
+        - PERSONAL_ID - A personal identifier is used as reference to a participant. Examples of personal identification are passport number, birth certificate number, and national registration number. The identifier number is added in the PartyIdentifier element. The personal identifier type is added in the PartySubIdOrType element.
+        
+        - BUSINESS - A specific Business (for example, an organization or a company) is used as reference to a participant. The BUSINESS identifier can be in any format. To make a transaction connected to a specific username or bill number in a Business, the PartySubIdOrType element should be used.
+        
+        - DEVICE - A specific device (for example, a POS or ATM) ID connected to a specific business or organization is used as reference to a Party. For referencing a specific device under a specific business or organization, use the PartySubIdOrType element.
+        
+        - ACCOUNT_ID - A bank account number or FSP account ID should be used as reference to a participant. The ACCOUNT_ID identifier can be in any format, as formats can greatly differ depending on country and FSP.
+        
+        - IBAN - A bank account number or FSP account ID is used as reference to a participant. The IBAN identifier can consist of up to 34 alphanumeric characters and should be entered without whitespace.
+        
+        - ALIAS An alias is used as reference to a participant. The alias should be created in the FSP as an alternative reference to an account owner. Another example of an alias is a username in the FSP system. The ALIAS identifier can be in any format. It is also possible to use the PartySubIdOrType element for identifying an account under an Alias defined by the PartyIdentifier.
+    PartyName:
+      title: PartyName
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Name of the Party. Could be a real name or a nickname.
+    PartySubIdOrType:
+      title: PartySubIdOrType
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Either a sub-identifier of a PartyIdentifier, or a sub-type of the PartyIdType, normally a PersonalIdentifierType.
+    PersonalIdentifierType:
+      title: PersonalIdentifierType
+      type: string
+      enum:
+      - PASSPORT
+      - NATIONAL_REGISTRATION
+      - DRIVING_LICENSE
+      - ALIEN_REGISTRATION
+      - NATIONAL_ID_CARD
+      - EMPLOYER_ID
+      - TAX_ID_NUMBER
+      - SENIOR_CITIZENS_CARD
+      - MARRIAGE_CERTIFICATE 
+      - HEALTH_CARD
+      - VOTERS_ID
+      - UNITED_NATIONS
+      - OTHER_ID
+      description: Below are the allowed values for the enumeration.
+      
+        - PASSPORT - A passport number is used as reference to a Party.
+        
+        - NATIONAL_REGISTRATION - A national registration number is used as reference to a Party.
+        
+        - DRIVING_LICENSE - A driving license is used as reference to a Party.
+        
+        - ALIEN_REGISTRATION - An alien registration number is used as reference to a Party.
+        
+        - NATIONAL_ID_CARD - A national ID card number is used as reference to a Party.
+        
+        - EMPLOYER_ID - A tax identification number is used as reference to a Party.
+        
+        - TAX_ID_NUMBER - A tax identification number is used as reference to a Party.
+        
+        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as reference to a Party.
+        
+        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as reference to a Party.
+        
+        - HEALTH_CARD - A health card number is used as reference to a Party.
+        
+        - VOTERS_ID - A voter’s identification number is used as reference to a Party.
+        
+        - UNITED_NATIONS - An UN (United Nations) number is used as reference to a Party.
+        
+        - OTHER_ID - Any other type of identification type number is used as reference to a Party.
+    QRCODE:
+      title: QRCODE
+      type: string
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: QR code used as a One Time Password.
+    RefundReason:
+      title: RefundReason
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Reason for the refund.
+    TokenCode:
+      title: TokenCode
+      type: string
+      pattern: ^[0-9a-zA-Z]{4,32}$
+      description: The API data type TokenCode is a JSON String between 4 and 32 characters, consisting of digits or upper- or lowercase characters from a to z.
+    TransactionInitiator:
+      title: TransactionInitiator
+      type: string
+      enum:
+      - PAYER
+      - PAYEE
+      description: Below are the allowed values for the enumeration. 
+      
+        - PAYER - Sender of funds is initiating the transaction. The account to send from is either owned by the Payer or is connected to the Payer in some way.
+        
+        - PAYEE - Recipient of the funds is initiating the transaction by sending a transaction request. The Payer must approve the transaction, either automatically by a pre-generated OTP or by pre-approval of the Payee, or by manually approving in his or her own Device.
+    TransactionInitiatorType:
+      title: TransactionInitiatorType
+      type: string
+      enum:
+      - CONSUMER
+      - AGENT
+      - BUSINESS
+      - DEVICE
+      description: Below are the allowed values for the enumeration.
+      
+        - CONSUMER - Consumer is the initiator of the transaction.
+        
+        - AGENT - Agent is the initiator of the transaction.
+        
+        - BUSINESS - Business is the initiator of the transaction.
+        
+        - DEVICE - Device is the initiator of the transaction.
+    TransactionRequestState:
+      title: TransactionRequestState
+      type: string
+      enum:
+      - RECEIVED
+      - PENDING
+      - ACCEPTED
+      - REJECTED
+      description: Below are the allowed values for the enumeration.
+      
+        - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
+        
+        - PENDING - Payer FSP has sent the transaction request to the Payer.
+        
+        - ACCEPTED - Payer has approved the transaction.
+        
+        - REJECTED - Payer has rejected the transaction.
+    TransactionScenario:
+      title: TransactionScenario
+      type: string
+      enum:
+      - DEPOSIT
+      - WITHDRAWAL
+      - TRANSFER
+      - PAYMENT
+      - REFUND
+      description: Below are the allowed values for the enumeration.
+      
+        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a normal scenario, electronic funds are transferred from a Business account to a Consumer account, and physical cash is given from the Consumer to the Business User.
+        
+        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction. In a normal scenario, electronic funds are transferred from a Consumer’s account to a Business account, and physical cash is given from the Business User to the Consumer.
+        
+        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to Consumer) transaction.
+        
+        - PAYMENT - Usually used for performing a transaction from a Consumer to a Merchant or Organization, but could also be for a B2B (Business to Business) payment. The transaction could be online for a purchase in an Internet store, in a physical store where both the Consumer and Business User are present, a bill payment, a donation, and so on.
+        
+        - REFUND - Used for performing a refund of transaction. 
+    TransactionState:
+      title: TransactionState
+      type: string
+      enum:
+      - RECEIVED
+      - PENDING
+      - COMPLETED
+      - REJECTED
+      description: Below are the allowed values for the enumeration.
+      
+        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
+        
+        - PENDING - Payee FSP has validated the transaction.
+        
+        - COMPLETED - Payee FSP has successfully performed the transaction.
+        
+        - REJECTED - Payee FSP has failed to perform the transaction.
+    TransactionSubScenario:
+      title: TransactionSubScenario
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: Possible sub-scenario, defined locally within the scheme (UndefinedEnum Type).
+    TransferState:
+      title: TransferState
+      type: string
+      enum:
+      - RECEIVED
+      - RESERVED
+      - COMMITTED
+      - ABORTED
+      description: Below are the allowed values for the enumeration.
+      
+        - RECEIVED - Next ledger has received the transfer.
+        
+        - RESERVED - Next ledger has reserved the transfer.
+        
+        - COMMITTED - Next ledger has successfully performed the transfer.
+        
+        - ABORTED - Next ledger has aborted the transfer due to a rejection or failure to perform the transfer.
+    UndefinedEnum:
+      title: UndefinedEnum
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: The API data type UndefinedEnum is a JSON String consisting of 1 to 32 uppercase characters including an underscore character (_).
+    
+    U2FResponse:
+      title: U2FResponse
+      type: object
+      description: U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.
+      properties:
+        challenge:
+          $ref: '#/components/schemas/U2FChallenge'
+          description: U2F challenge-response.
+        counter:
+          $ref: '#/components/schemas/Counter'
+          description: Sequential counter used for cloning detection. Present only for U2F authentication.
+      required:
+      - challenge
+      - counter
+    U2FChallenge:
+      title: U2FChallenge
+      type: string
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.     
+    Counter:
+      title: Counter
+      $ref: '#/components/schemas/Integer'
+      description: Sequential counter used for cloning detection. Present only for U2F authentication.
+    RetriesLeft:
+      title: RetriesLeft
+      $ref: '#/components/schemas/Integer' 
+      description: RetriesLeft is the number of retries left before the financial transaction is rejected. It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected.
+ 
+  #Complex Types
+    AuthenticationInfo:
+      title: AuthenticationInfo
+      type: object
+      description: Data model for the complex type AuthenticationInfo.
+      properties:
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+          description: Type of authentication.          
+        authenticationValue:
+          $ref: '#/components/schemas/AuthenticationValue'
+          description: Authentication value.
+      required:
+      - authentication
+      - authenticationValue
+
+    AuthorizationsPostRequest:
+      title: AuthorizationsPostRequest
+      type: object
+      description: POST /authorizations Request object
+      properties:
+        authenticationType:
+          $ref: '#/components/schemas/AuthenticationType'
+          description: This value is a valid authentication type from the enumeration AuthenticationType(OTP or QR Code or U2F).
+        retriesLeft:
+          $ref: '#/components/schemas/RetriesLeft'
+          description: RetriesLeft is the number of retries left before the financial transaction is rejected. It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected.
+        amount:
+          $ref: '#/components/schemas/Money'
+          description: This is the transaction amount that will be withdrawn from the Payer’s account.
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+          description: Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. 
+        transactionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+          description: The transactionRequestID, received from the POST /transactionRequests service earlier in the process. 
+        quote:
+          $ref: '#/components/schemas/QuotesIDPutResponse'
+          description: Quotes object
+      required:
+      - authenticationType
+      - retriesLeft
+      - amount
+      - currency
+      - transactionId
+      - transactionRequestId
+      - quote
+      
+    AuthorizationsIDPutResponse:
+      title: AuthorizationsIDPutResponse
+      type: object
+      description: The object sent in the PUT /authorizations/{ID} callback.
+      properties:
+        authenticationInfo:
+          $ref: '#/components/schemas/AuthenticationInfo'
+          description: OTP or QR Code if entered, otherwise empty.
+        responseType:
+          type: string
+          description: Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.
+          example: ENTERED
+      required:
+      - responseType
+    BulkQuotesIDPutResponse:
+      title: BulkQuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkQuotes/{ID} callback.
+      properties:
+        individualQuoteResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/IndividualQuoteResult'
+          description: Fees for each individual transaction, if any of them are charged per transaction.
+        expiration:
+          type: string
+          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction request.
+          example: '2016-05-24T08:38:08.699-04:00'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - expiration
+    BulkQuotesPostRequest:
+      title: BulkQuotesPostRequest
+      type: object
+      description: The object sent in the POST /bulkQuotes request.
+      properties:
+        bulkQuoteId:
+          type: string
+          description: Common ID between the FSPs for the bulk quote object, decided by the Payer FSP. The ID should be reused for resends of the same bulk quote. A new ID should be generated for each new bulk quote.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        payer:
+          properties:
+            partyIdInfo:
+              $ref: '#/components/schemas/PartyIdInfo'
+              description: Party Id type, id, sub ID or type, and FSP Id.
+            merchantClassificationCode:
+              type: string
+              description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
+              example: 1234
+            name:
+              type: string
+              description: Display name of the Party, could be a real name or a nick name.
+              example: Henrik Karlsson
+            personalInfo:
+              $ref: '#/components/schemas/PartyPersonalInfo'
+              description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
+        expiration: 
+          type: string
+          description: Expiration is optional to let the Payee FSP know when a quote no longer needs to be returned.
+          example: '2016-05-24T08:38:08.699-04:00'
+        individualQuotes:
+          properties:
+            quoteId:
+              type: string
+              description: Identifies quote message.
+              example: b51ec534-ee48-4575-b6a9-ead2955b8069
+            transactionId:
+              type: string
+              description: Identifies transaction message.
+              example: b51ec534-ee48-4575-b6a9-ead2955b8069
+            payee:
+              properties:
+                partyIdInfo:
+                  $ref: '#/components/schemas/PartyIdInfo'
+                  description: Party Id type, id, sub ID or type, and FSP Id.
+                merchantClassificationCode:
+                  type: string
+                  description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
+                  example: 1234
+                name:
+                  type: string
+                  description: Display name of the Party, could be a real name or a nick name.
+                  example: Henrik Karlsson
+                personalInfo:
+                  $ref: '#/components/schemas/PartyPersonalInfo'
+                  description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
+            amountType:
+              type: string
+              description: SEND for sendAmount, RECEIVE for receiveAmount.
+              example: RECEIVE
+            amount:
+              properties:
+                currency:
+                  type: string
+                  description: Currency of the amount.
+                  example: USD
+                amount:
+                  type: string
+                  description: Amount of money.
+                  example: 123.45
+              #$ref: '#/components/schemas/Money'
+              #description: Depending on amountType:
+                #If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
+                #If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive of any fees. The amount is not updated by any of the participating entities.
+            fees:
+              properties:
+                currency:
+                  type: string
+                  description: Currency of the amount.
+                  example: USD
+                amount:
+                  type: string
+                  description: Amount of money.
+                  example: 1.45
+              #$ref: '#/components/schemas/Money'
+              #description: The fees in the transaction.
+                #The fees element should be empty if fees should be non-disclosed.
+                #The fees element should be non-empty if fees should be disclosed.
+            transactionType:
+              $ref: '#/components/schemas/TransactionType'
+              description: Type of transaction that the quote is requested for.
+            note:
+              type: string
+              description: Memo that will be attached to the transaction.
+              example: Note sent to Payee.  
+            extensionList:
+                $ref: '#/components/schemas/ExtensionList'
+                description: Optional extension, specific to deployment.
+      required:
+      - bulkQuoteId
+      - payer
+      - individualQuotes
+    BulkTransfersIDPutResponse:
+      title: BulkTransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkTransfers/{ID} callback.
+      properties:
+        completedTimestamp:
+          type: string
+          description: Time and date when the bulk transaction was completed.
+          example: '2016-05-24T08:38:08.699-04:00'
+        individualTransferResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/IndividualTransferResult'
+          description: List of IndividualTransferResult elements.
+        bulkTransferState:
+          type: string
+          description: The state of the bulk transfer.
+          example: RECEIVED
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - bulkTransferState
+    BulkTransfersPostRequest:
+      title: BulkTransfersPostRequest
+      type: object
+      description: The object sent in the POST /bulkTransfers request.
+      properties:
+        bulkTransferId:
+          type: string
+          description: Common ID between the FSPs and the optional Switch for the bulk transfer object, decided by the Payer FSP. The ID should be reused for resends of the same bulk transfer. A new ID should be generated for each new bulk transfer.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        bulkQuoteId:
+          type: string
+          description: ID of the related bulk quote.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        payerFsp:
+          type: string
+          description: Payer FSP identifier.
+          example: 5678
+        payeeFsp:
+          type: string
+          description: Payee FSP identifier.
+          example: 1234
+        individualTransfers:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/IndividualTransfer'
+          description: List of IndividualTransfer elements.
+        expiration:
+          type: string
+          description: Expiration time of the transfers.
+          example: '2016-05-24T08:38:08.699-04:00'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - bulkTransferId
+      - bulkQuoteId
+      - payerFsp
+      - payeeFsp
+      - individualTransfers
+      - expiration
+    ErrorInformation:
+      title: ErrorInformation
+      type: object
+      description: Data model for the complex type ErrorInformation.
+      properties:
+        errorCode:
+          type: string
+          description: Specific error number.
+          example: 5100
+        errorDescription:
+          type: string
+          description: Error description string.
+          example: This is an error description.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+      - errorCode
+      - errorDescription
+    ErrorInformationObject:
+      title: ErrorInformationObject
+      type: object
+      description: Data model for the complex type object that contains ErrorInformation.
+      properties:
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+      required:
+      - errorInformation
+    ErrorInformationResponse:
+      title: ErrorInformationResponse
+      type: object
+      description: Data model for the complex type object that contains an optional element ErrorInformation used along with 4xx and 5xx responses.
+      properties:
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+    Extension:
+      title: Extension
+      type: object
+      description: Data model for the complex type Extension.
+      properties:
+        key:
+          type: string
+          description: Extension key.
+        value:
+          type: string
+          description: Extension value.
+      required:
+      - key
+      - value
+    ExtensionList:
+      title: ExtensionList
+      type: object
+      description: Data model for the complex type ExtensionList. An optional list of extensions, specific to deployment.
+      properties:
+        extension:
+          type: array
+          items:
+            $ref: '#/components/schemas/Extension'
+          minItems: 1
+          maxItems: 16
+          description: Number of Extension elements.
+      required:
+      - extension
+    GeoCode:
+      title: GeoCode
+      type: object
+      description: Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.
+      properties:
+        latitude:
+          type: string
+          description: Latitude of the Party.
+          example: '+45.4215'
+        longitude:
+          type: string
+          description: Longitude of the Party.
+          example: '+75.6972'
+      required:
+      - latitude
+      - longitude
+    IndividualQuote:
+      title: IndividualQuote
+      type: object
+      description: Data model for the complex type IndividualQuote.
+      properties:
+        quoteId:
+          type: string
+          description: Identifies the quote message.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        transactionId:
+          type: string
+          description: Identifies the transaction message.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        payee:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payee in the proposed financial transaction.
+        amountType:
+          type: string
+          description: SEND for sendAmount, RECEIVE for receiveAmount.
+          example: RECEIVE
+        amount:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 123.45
+          #$ref: '#/components/schemas/Money'
+          #description: Depending on amountType:
+            #If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
+            #If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive of any fees. The amount is not updated by any of the participating entities.
+        fees:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 1.45
+          #$ref: '#/components/schemas/Money'
+          #description: The fees in the transaction.
+            #The fees element should be empty if fees should be non-disclosed.
+            #The fees element should be non-empty if fees should be disclosed.
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+          description: Type of transaction that the quote is requested for.
+        note:
+          type: string
+          description: Memo that will be attached to the transaction.
+          example: Note sent to Payee.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - quoteId
+      - transactionId
+      - payee
+      - amountType
+      - amount
+      - transactionType
+    IndividualQuoteResult:
+      title: IndividualQuoteResult
+      type: object
+      description: Data model for the complex type IndividualQuoteResult.
+      properties:
+        quoteId:
+          type: string
+          description: Identifies the quote message.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        payee:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payee in the proposed financial transaction.
+        transferAmount:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 124.45
+          #$ref: '#/components/schemas/Money'
+          #description: The amount of money that the Payee FSP should receive.
+        payeeReceiveAmount:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 123.45
+          #$ref: '#/components/schemas/Money'
+          #description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
+        payeeFspFee:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 1.45
+          #$ref: '#/components/schemas/Money'
+          #description: Payee FSP’s part of the transaction fee.
+        payeeFspCommission:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 1.45
+          #$ref: '#/components/schemas/Money'
+          #description: Transaction commission from the Payee FSP.
+        ilpPacket:
+          type: string
+          description: The ILP Packet that must be attached to the transfer by the Payer.
+          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+        condition:
+          type: string
+          description: The condition that must be attached to the transfer by the Payer.
+          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+          description: Error code, category description. **Note:** receiveAmount, payeeFspFee, payeeFspCommission, expiration, ilpPacket, condition should not be set if errorInformation is set.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - quoteId
+    IndividualTransfer:
+      title: IndividualTransfer
+      type: object
+      description: Data model for the complex type IndividualTransfer.
+      properties:
+        transferId:
+          type: string
+          description: Identifies messages related to the same /transfers sequence.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        transferAmount:
+          $ref: '#/components/schemas/Money'
+          description: Transaction amount to be sent.
+        ilpPacket:
+          type: string
+          description: ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
+          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+        condition:
+          type: string
+          description: Condition that must be fulfilled to commit the transfer.
+          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transferId
+      - transferAmount
+      - ilpPacket
+      - condition
+    IndividualTransferResult:
+      title: IndividualTransferResult
+      type: object
+      description: Data model for the complex type IndividualTransferResult.
+      properties:
+        transferId:
+          type: string
+          description: Identifies messages related to the same /transfers sequence.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        fulfilment:
+          type: string
+          description: Fulfilment of the condition specified with the transaction. **Note:** Either fulfilment or errorInformation should be set, not both.
+          example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+          description: If transfer is REJECTED, error information may be provided. **Note:** Either fulfilment or errorInformation should be set, not both.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transferId
+    Money:
+      title: Money
+      type: object
+      description: Data model for the complex type Money.
+      properties:
+        currency:
+          type: string
+          description: Currency of the amount.
+          example: USD
+        amount:
+          type: string
+          description: Amount of Money.
+          example: 123.45
+      required:
+      - currency
+      - amount
+    ParticipantsIDPutResponse:
+      title: ParticipantsIDPutResponse
+      type: object
+      description: The object sent in the PUT /participants/{ID} callback.
+      properties:
+        partyList:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartyResult'
+          minItems: 1
+          maxItems: 10000
+          description: List of PartyResult elements that were either created or failed to be created.
+        currency:
+          type: string
+          description: Indicate that the provided Currency was set to be supported by each successfully added PartyIdInfo.
+          example: USD
+      required:
+        - partyList
+    ParticipantsPostRequest:
+      title: ParticipantsPostRequest
+      type: object
+      description: The object sent in the POST /participants request.
+      properties:
+        requestId:
+          type: string
+          description: The ID of the request, decided by the client. Used for identification of the callback from the server.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        partyList:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartyIdInfo'
+          minItems: 1
+          maxItems: 10000
+          description: List of PartyIdInfo elements that the client would like to update or create FSP information about.
+        currency:
+          type: string
+          description: Indicate that the provided Currency is supported by each PartyIdInfo in the list.
+          example: USD
+      required:
+      - requestId
+      - partyList
+    ParticipantsTypeIDPutResponse:
+      title: ParticipantsTypeIDPutResponse
+      type: object
+      description: The object sent in the PUT /participants/{Type}/{ID}/{SubId} and /participants/{Type}/{ID} callbacks. 
+      properties:
+        fspId:
+          type: string
+          description: FSP Identifier that the Party belongs to.
+          example: 1234  
+    ParticipantsTypeIDSubIDPostRequest:
+      title: ParticipantsTypeIDSubIDPostRequest
+      type: object
+      description: The object sent in the POST /participants/{Type}/{ID}/{SubId} and /participants/{Type}/{ID} requests.
+      properties:
+        fspId:
+          type: string
+          description: FSP Identifier that the Party belongs to.
+          example: 1234
+        currency:
+          type: string
+          description: Indicate that the provided Currency is supported by the Party.
+          example: USD
+      required:
+      - fspId
+    PartiesTypeIDPutResponse:
+      title: PartiesTypeIDPutResponse
+      type: object
+      description: The object sent in the PUT /parties/{Type}/{ID} callback.
+      properties:
+        party:
+          $ref: '#/components/schemas/Party'
+          description: Information regarding the requested Party.
+      required:
+      - party
+    Party:
+      title: Party
+      type: object
+      description: Data model for the complex type Party.
+      properties:
+        partyIdInfo:
+          $ref: '#/components/schemas/PartyIdInfo'
+          description: Party Id type, id, sub ID or type, and FSP Id.
+        merchantClassificationCode:
+          type: string
+          description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
+          example: 4321
+        name:
+          type: string
+          description: Display name of the Party, could be a real name or a nick name.
+          example: Henrik Karlsson
+        personalInfo:
+          $ref: '#/components/schemas/PartyPersonalInfo'
+          description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
+      required:
+      - partyIdInfo
+    PartyComplexName:
+      title: PartyComplexName
+      type: object
+      description: Data model for the complex type PartyComplexName.
+      properties:
+        firstName:
+          type: string
+          description: Party’s first name.
+          example: Henrik
+        middleName:
+          type: string
+          description: Party’s middle name.
+          example: Johannes
+        lastName:
+          type: string
+          description: Party’s last name.
+          example: Karlsson
+    PartyIdInfo:
+      title: PartyIdInfo
+      type: object
+      description: Data model for the complex type PartyIdInfo.
+      properties:
+        partyIdType:
+          type: string
+          description: Type of the identifier.
+          example: PERSONAL_ID
+        partyIdentifier:
+          type: string
+          description: An identifier for the Party.
+          example: 16135551212
+        partySubIdOrType:
+          type: string
+          description: A sub-identifier or sub-type for the Party.
+          example: DRIVING_LICENSE
+        fspId:
+          type: string
+          description: FSP ID (if known).
+          example: 1234
+      required:
+        - partyIdType
+        - partyIdentifier
+    PartyPersonalInfo:
+      title: PartyPersonalInfo
+      type: object
+      description: Data model for the complex type PartyPersonalInfo.
+      properties:
+        complexName:
+          $ref: '#/components/schemas/PartyComplexName'
+          description: First, middle and last name for the Party.
+        dateOfBirth:
+          type: string
+          description: Date of birth for the Party.
+          example: '1966-06-16'
+    PartyResult:
+      title: PartyResult
+      type: object
+      description: Data model for the complex type PartyResult.
+      properties:
+        partyId:
+          $ref: '#/components/schemas/PartyIdInfo'
+          description: Party Id type, id, sub ID or type, and FSP Id.
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+          description: If the Party failed to be added, error information should be provided. Otherwise, this parameter should be empty to indicate success.
+      required:
+        - partyId
+    QuotesIDPutResponse:
+      title: QuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /quotes/{ID} callback.
+      properties:
+        transferAmount:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 124.45
+          #$ref: '#/components/schemas/Money'
+          #description: The amount of money that the Payee FSP should receive.
+        payeeReceiveAmount:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 123.45
+          #$ref: '#/components/schemas/Money'
+          #description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
+        payeeFspFee:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 1.45
+          #$ref: '#/components/schemas/Money'
+          #description: Payee FSP’s part of the transaction fee.
+        payeeFspCommission:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 0
+          #$ref: '#/components/schemas/Money'
+          #description: Transaction commission from the Payee FSP.
+        expiration:
+          type: string
+          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.
+          example: '2016-05-24T08:38:08.699-04:00'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+          description: Longitude and Latitude of the Payee. Can be used to detect fraud.
+        ilpPacket:
+          type: string
+          description: The ILP Packet that must be attached to the transfer by the Payer.
+          example: “AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA” 
+        condition:
+          type: string
+          description: The condition that must be attached to the transfer by the Payer.
+          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transferAmount
+      - expiration
+      - ilpPacket
+      - condition
+    QuotesPostRequest:
+      title: QuotesPostRequest
+      type: object
+      description: The object sent in the POST /quotes request.
+      properties:
+        quoteId:
+          type: string
+          description: Common ID between the FSPs for the quote object, decided by the Payer FSP. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        transactionId:
+          type: string
+          description: Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
+          example: a8323bc6-c228-4df2-ae82-e5a997baf899
+        transactionRequestId:
+          type: string
+          description: Identifies an optional previously-sent transaction request.
+          example: a8323bc6-c228-4df2-ae82-e5a997baf890
+        payee:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payee in the proposed financial transaction.
+        payer:
+          properties:
+            partyIdInfo:
+              properties:
+                partyIdType:
+                  type: string
+                  description: Information about the Payer in the proposed financial transaction. Type of the identifier.
+                  example: PERSONAL_ID
+                partyIdentifier:
+                  type: string
+                  description: Information about the Payer in the proposed financial transaction. An indentifier for the Party.
+                  example: 16135551212
+                partySubIdOrType:
+                  type: string
+                  description: Information about the Payer in the proposed financial transaction. A sub-identifier or sub-type for the Party.
+                  example: PASSPORT
+                fspId:
+                  type: string
+                  description: FSP ID (if known).
+                  example: 1234
+            merchantClassificationCode:
+              type: string
+              description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
+              example: 1234
+            name: 
+              type: string
+              description: Display name of the Party, could be a real name or a nick name.
+              example: Lars Bergqvist
+            personalInfo:
+              properties:
+                complexName:
+                  properties:
+                    firstName:
+                      type: string
+                      description: Party’s first name.
+                      example: Lars
+                    middleName:
+                      type: string
+                      description: Party’s middle name.
+                      example: Per
+                    lastName:
+                      type: string
+                      description: Party’s last name.
+                      example: Bergqvist
+                dateOfBirth:
+                  type: string
+                  description: Date of birth for the Party.
+                  example: '1977-07-17'
+        amountType:
+          type: string
+          description: SEND for send amount, RECEIVE for receive amount.
+          example: SEND
+        amount:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 123.45
+          #$ref: '#/components/schemas/Money'
+          #description: Depending on amountType: 
+            #If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
+            #If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities.
+        fees:
+          properties:
+            currency:
+              type: string
+              description: Currency of the amount.
+              example: USD
+            amount:
+              type: string
+              description: Amount of money.
+              example: 1.25
+          #$ref: '#/components/schemas/Money'
+          #description: The fees in the transaction.
+            #The fees element should be empty if fees should be non-disclosed.
+            #The fees element should be non-empty if fees should be disclosed.
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+          description: Type of transaction for which the quote is requested.
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
+        note:
+          type: string
+          description: A memo that will be attached to the transaction.
+          example: Free-text memo.
+        expiration:
+          type: string
+          description: Expiration is optional. It can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, and Merchant to know that their request has a time limit.
+          example: '2016-05-24T08:38:08.699-04:00'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - quoteId
+      - transactionId
+      - payee
+      - payer
+      - amountType
+      - amount
+      - transactionType
+    Refund:
+      title: Refund
+      type: object
+      description: Data model for the complex type Refund.
+      properties:
+        originalTransactionId:
+          type: string
+          description: Reference to the original transaction ID that is requested to be refunded.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        refundReason:
+          type: string
+          description: Free text indicating the reason for the refund.
+          example: Free text indicating reason for the refund.
+      required:
+      - originalTransactionId
+    Transaction:
+      title: Transaction
+      type: object
+      description: Data model for the complex type Transaction. The Transaction type is used to carry end-to-end data between the Payer FSP and the Payee FSP in the ILP Packet. Both the transactionId and the quoteId in the data model are decided by the Payer FSP in the POST /quotes request.
+      properties:
+        transactionId:
+          type: string
+          description: ID of the transaction, the ID is decided by the Payer FSP during the creation of the quote.
+        quoteId:
+          type: string
+          description: ID of the quote, the ID is decided by the Payer FSP during the creation of the quote.
+        payee:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payee in the proposed financial transaction.
+        payer:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payer in the proposed financial transaction.
+        amount:
+          $ref: '#/components/schemas/Money'
+          description: Transaction amount to be sent.
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+          description: Type of the transaction.
+        note:
+          type: string
+          description: Memo associated to the transaction, intended to the Payee.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transactionId
+      - quoteId
+      - payee
+      - payer
+      - amount
+      - transactionType
+    TransactionRequestsIDPutResponse:
+      title: TransactionRequestsIDPutResponse
+      type: object
+      description: The object sent in the PUT /transactionRequests/{ID} callback.
+      properties:
+        transactionId:
+          type: string
+          description: Identifies a related transaction (if a transaction has been created).
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        transactionRequestState:
+          type: string
+          description: State of the transaction request.
+          example: RECEIVED
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transactionRequestState
+    TransactionRequestsPostRequest:
+      title: TransactionRequestsPostRequest
+      type: object
+      description: The object sent in the POST /transactionRequests request.
+      properties:
+        transactionRequestId:
+          type: string
+          description: Common ID between the FSPs for the transaction request object, decided by the Payee FSP. The ID should be reused for resends of the same transaction request. A new ID should be generated for each new transaction request.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        payee:
+          $ref: '#/components/schemas/Party'
+          description: Information about the Payee in the proposed financial transaction.
+        payer:
+          $ref: '#/components/schemas/PartyIdInfo'
+          description: Information about the Payer type, id, sub-type/id, FSP Id in the proposed financial transaction.
+        amount:
+          $ref: '#/components/schemas/Money'
+          description: Requested amount to be transferred from the Payer to Payee.
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+          description: Type of transaction.
+        note:
+          type: string
+          description: Reason for the transaction request, intended to the Payer.
+          example: Free-text memo.
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
+        authenticationType:
+          type: string
+          description: OTP or QR Code, otherwise empty.
+          example: OTP
+        expiration:
+          type: string
+          description: Can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, Merchant to know that their request has a time limit.
+          example: '2016-05-24T08:38:08.699-04:00'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transactionRequestId
+      - payee
+      - payer
+      - amount
+      - transactionType
+    TransactionsIDPutResponse:
+      title: TransactionsIDPutResponse
+      type: object
+      description: The object sent in the PUT /transactions/{ID} callback.
+      properties:
+        completedTimestamp:
+          type: string
+          description: Time and date when the transaction was completed.
+          example: '2016-05-24T08:38:08.699-04:00'
+        transactionState:
+          type: string
+          description: State of the transaction.
+          example: RECEIVED
+        code:
+          type: string
+          description: Optional redemption information provided to Payer after transaction has been completed.
+          example: Test-Code
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transactionState
+    TransactionType:
+      title: TransactionType
+      type: object
+      description: Data model for the complex type TransactionType.
+      properties:
+        scenario:
+          type: string
+          description: Deposit, withdrawal, refund, …
+          example: DEPOSIT
+        subScenario:
+          type: string
+          description: Possible sub-scenario, defined locally within the scheme.
+          example: Locally defined sub-scenario.
+        initiator:
+          type: string
+          description: Who is initiating the transaction - Payer or Payee.
+          example: PAYEE
+        initiatorType:
+          type: string
+          description: Consumer, agent, business, …
+          example: CONSUMER
+        refundInfo:
+          $ref: '#/components/schemas/Refund'
+          description: Extra information specific to a refund scenario. Should only be populated if scenario is REFUND.
+        balanceOfPayments:
+          type: string
+          description: Balance of Payments code.
+          example: 123
+      required:
+      - scenario
+      - initiator
+      - initiatorType
+    TransfersIDPutResponse:
+      title: TransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /transfers/{ID} callback.
+      properties:
+        fulfilment:
+          type: string
+          description: Fulfilment of the condition specified with the transaction. Mandatory if transfer has completed successfully.
+          example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+        completedTimestamp:
+          type: string
+          description: Time and date when the transaction was completed.
+          example: '2016-05-24T08:38:08.699-04:00'
+        transferState:
+          type: string
+          description: State of the transfer.
+          example: RESERVED
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transferState
+    TransfersPostRequest:
+      title: TransfersPostRequest
+      type: object
+      description: The object sent in the POST /transfers request.
+      properties:
+        transferId:
+          type: string
+          description: The common ID between the FSPs and the optional Switch for the transfer object, decided by the Payer FSP. The ID should be reused for resends of the same transfer. A new ID should be generated for each new transfer.
+          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+        payeeFsp:
+          type: string
+          description: Payee FSP in the proposed financial transaction.
+          example: 1234
+        payerFsp:
+          type: string
+          description: Payer FSP in the proposed financial transaction.
+          example: 5678
+        amount:
+          $ref: '#/components/schemas/Money'
+          description: The transfer amount to be sent.
+        ilpPacket:
+          type: string
+          description: The ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
+          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+        condition:
+          type: string
+          description: The condition that must be fulfilled to commit the transfer.
+          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
+        expiration:
+          type: string
+          description: Expiration can be set to get a quick failure expiration of the transfer. The transfer should be rolled back if no fulfilment is delivered before this time.
+          example: '2016-05-24T08:38:08.699-04:00'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+          description: Optional extension, specific to deployment.
+      required:
+      - transferId
+      - payeeFsp
+      - payerFsp
+      - amount
+      - ilpPacket
+      - condition
+      - expiration
+    
+      
+  responses:
+    '200':
+      description: OK
+    '202':
+      description: Accepted
+    '400':
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '401':  
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '403':
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '405':
+      description: Method Not Allowed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '406':
+      description: Not Acceptable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '501':
+      description: Not Implemented
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+    '503':
+      description: Service Unavailable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/parameters/Content-Length'
+        Content-Type:
+          $ref: '#/components/parameters/Content-Type'
+  
+  parameters:
+  #Header parameters
+    Accept:
+      name: Accept
+      in: header
+      required: true
+      schema:
+        type: string
+      description: The `Accept` header field indicates the version of the API the client would like the server to use.
+    Content-Length:
+      name: Content-Length
+      in: header
+      required: false
+      schema:
+        type: integer
+      description: The `Content-Length` header field indicates the anticipated size of the payload body. Only sent if there is a body. 
+      
+      
+        **Note:** The API supports a maximum size of 5242880 bytes (5 Megabytes).
+    Content-Type:
+      name: Content-Type
+      in: header
+      schema:
+        type: string
+      required: true
+      description: The `Content-Type` header indicates the specific version of the API used to send the payload body.
+    Date:
+      name: Date
+      in: header
+      schema:
+        type: string
+      required: true
+      description: The `Date` header field indicates the date when the request was sent.
+    X-Forwarded-For:
+      name: X-Forwarded-For
+      in: header
+      schema:
+        type: string
+      required: false
+      description: The `X-Forwarded-For` header field is an unofficially accepted standard used for informational purposes of the originating client IP address, as a request might pass multiple proxies, firewalls, and so on. Multiple `X-Forwarded-For` values should be expected and supported by implementers of the API.
+          
+          
+          **Note:** An alternative to `X-Forwarded-For` is defined in [RFC 7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
+    FSPIOP-Source:
+      name: FSPIOP-Source
+      in: header
+      schema:
+        type: string
+      required: true
+      description: The `FSPIOP-Source` header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. The field should be set by the original sender of the request. Required for routing and signature verification (see header field `FSPIOP-Signature`).
+    FSPIOP-Destination:
+      name: FSPIOP-Destination
+      in: header
+      schema:
+        type: string
+      required: false
+      description: The `FSPIOP-Destination` header field is a non-HTTP standard field used by the API for HTTP header based routing of requests and responses to the destination. The field should be set by the original sender of the request (if known), so that any entities between the client and the server do not need to parse the payload for routing purposes.
+    FSPIOP-Encryption:
+      name: FSPIOP-Encryption
+      in: header
+      schema:
+        type: string
+      required: false
+      description: The `FSPIOP-Encryption` header field is a non-HTTP standard field used by the API for applying end-to-end encryption of the request.
+    FSPIOP-Signature:
+      name: FSPIOP-Signature
+      in: header
+      schema:
+        type: string
+      required: false
+      description: The `FSPIOP-Signature` header field is a non-HTTP standard field used by the API for applying an end-to-end request signature.
+    FSPIOP-URI:
+      name: FSPIOP-URI
+      in: header
+      schema:
+        type: string
+      required: false
+      description: The `FSPIOP-URI` header field is a non-HTTP standard field used by the API for signature verification, should contain the service URI. Required if signature verification is used, for more information, see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+    FSPIOP-HTTP-Method:
+      name: FSPIOP-HTTP-Method
+      in: header
+      schema:
+        type: string
+      required: false
+      description: The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by the API for signature verification, should contain the service HTTP method. Required if signature verification is used, for more information, see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+  #Path parameters
+    ID:
+      name: ID
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The identifier value.  
+    Type:
+      name: Type
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
+    SubId:
+      name: SubId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: A sub-identifier of the party identifier, or a sub-type of the party identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.  

--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
@@ -2683,7 +2683,7 @@ components:
       properties:
         authenticationInfo:
           $ref: '#/components/schemas/AuthenticationInfo'
-          description: OTP or QR Code if entered, otherwise empty.
+          description: OTP or QR Code or U2F if entered, otherwise empty.
         responseType:
           type: string
           description: Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.
@@ -3626,7 +3626,7 @@ components:
           description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
         authenticationType:
           type: string
-          description: OTP or QR Code, otherwise empty.
+          description: OTP or QR Code or U2F, otherwise empty.
           example: OTP
         expiration:
           type: string

--- a/docs/git_branching.md
+++ b/docs/git_branching.md
@@ -5,8 +5,8 @@
   3. Newly created PR for every WIP branch should have `pisp/master` set as target
   4. When the new version of `master` is published (by other team for example), we should propagate all changes via merge with `pisp/master`
   
-## PISP changes in other repos
-   1. [#269](https://github.com/mojaloop/mojaloop/issues/269) POST /authorizations swagger changes in `mojaloop-specification` and `transaction-requests-service`
-        - https://github.com/mojaloop/mojaloop-specification/commit/03d63c7d10c5a29a229d0ed8a5d92323489caeda
-        - https://github.com/mojaloop/transaction-requests-service/commit/61196e5bab654c47cb3fe057b296778e5ee68782
+## PISP changes in other Repos :
+   1. POST /authorizations Swagger changes [#269](https://github.com/mojaloop/mojaloop/issues/269)
+        - [mojaloop-specification](https://github.com/mojaloop/mojaloop-specification/commit/6ca00674e96990053926da29a2af3f07cf71b976)
+        - [transaction-requests-service](https://github.com/mojaloop/transaction-requests-service/commit/05c6b822bbb53e5d7eac4003d3369e6c09b67459)
         

--- a/docs/git_branching.md
+++ b/docs/git_branching.md
@@ -4,3 +4,9 @@
   2. We have `pisp/master` leading branch to keep our final feature candidate to be merged with `master`
   3. Newly created PR for every WIP branch should have `pisp/master` set as target
   4. When the new version of `master` is published (by other team for example), we should propagate all changes via merge with `pisp/master`
+  
+## PISP changes in other repos
+   1. [#269](https://github.com/mojaloop/mojaloop/issues/269) POST /authorizations swagger changes in `mojaloop-specification` and `transaction-requests-service`
+        - https://github.com/mojaloop/mojaloop-specification/commit/03d63c7d10c5a29a229d0ed8a5d92323489caeda
+        - https://github.com/mojaloop/transaction-requests-service/commit/61196e5bab654c47cb3fe057b296778e5ee68782
+        

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,0 +1,2926 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Transaction Requests related parts of Open API for FSP Interoperability (FSPIOP) (Implementation Friendly Version)",
+        "version": "1.0",
+        "description": "Based on API Definition.docx updated on 2018-03-13 Version 1.0. Note - The API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP header.",
+        "license": {
+            "name": "Open API for FSP Interoperability (FSPIOP) (Implementation Friendly Version)"
+        }
+    },
+    "basePath": "/",
+    "schemes": [
+        "http"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/health": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/ResponseHealth200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "HealthGet",
+                "summary": "Get Server",
+                "description": "The HTTP request GET /health is used to return the current status of the API."
+            }
+        },
+        "/metrics": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "metrics"
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/ResponseHealth200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "MetricsGet",
+                "summary": "Prometheus metrics endpoint",
+                "description": "The HTTP request GET /metrics is used to return metrics for the API."
+            }
+        },
+        "/transactionRequests/{ID}/error": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactionRequests",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ID"
+                    },
+                    {
+                        "name": "body",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorInformationObject"
+                        },
+                        "in": "body",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Length"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/Response200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "TransactionRequestsErrorByID",
+                "summary": "TransactionRequestsErrorByID",
+                "description": "If the server is unable to find or create a transaction request, or another processing error occurs, the error callback PUT /transactionRequests/<ID>/error is used. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request, or the <ID> that was used in the GET /transactionRequests/<ID>.",
+                "x-examples": {
+                    "application/json": {
+                        "“errorInformation”": {
+                            "“errorCode”": "“5100”",
+                            "“errorDescription”": "“This is an error description”",
+                            "extensionList": {
+                                "extension": [
+                                    {
+                                        "“key”": "“errorDescription”",
+                                        "“value”": "“This is a more detailed error description”"
+                                    },
+                                    {
+                                        "“key”": "“errorDescription”",
+                                        "“value”": "“This is a more detailed error description”"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/transactionRequests/{ID}": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactionRequests",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/Accept"
+                    },
+                    {
+                        "$ref": "#/parameters/ID"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "$ref": "#/responses/Response202"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "TransactionRequestsByID",
+                "summary": "TransactionRequestsByID",
+                "description": "The HTTP request GET /transactionRequests/<ID> is used to get information regarding an earlier created or requested transaction request. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request."
+            },
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactionRequests",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionRequestsIDPutResponse"
+                        },
+                        "in": "body",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Length"
+                    },
+                    {
+                        "$ref": "#/parameters/ID"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/Response200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "TransactionRequestsByIDPut",
+                "summary": "TransactionRequestsByID",
+                "description": "The callback PUT /transactionRequests/<ID> is used to inform the client of a requested or created transaction request. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request, or the <ID> that was used in the GET /transactionRequests/<ID>.",
+                "x-examples": {
+                    "application/json": {
+                        "“transactionId”": "“b51ec534-ee48-4575-b6a9-ead2955b8069”",
+                        "“transactionRequestState”": "“RECEIVED”",
+                        "extensionList": {
+                            "extension": [
+                                {
+                                    "“key”": "“errorDescription”",
+                                    "“value”": "“This is a more detailed error description”"
+                                },
+                                {
+                                    "“key”": "“errorDescription”",
+                                    "“value”": "“This is a more detailed error description”"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        "/transactionRequests": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transactionRequests",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "schema": {
+                            "$ref": "#/definitions/TransactionRequestsPostRequest"
+                        },
+                        "in": "body",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/Accept"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Length"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "$ref": "#/responses/Response202"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "TransactionRequests",
+                "summary": "TransactionRequests",
+                "description": "The HTTP request POST /transactionRequests is used to request the creation of a transaction request for the provided financial transaction in the server.",
+                "x-examples": {
+                    "application/json": {
+                        "“transactionRequestId”": "“b51ec534-ee48-4575-b6a9-ead2955b8069”",
+                        "“payee”": {
+                            "partyIdInfo": {
+                                "“partyIdType”": "“PERSONAL_ID”",
+                                "“partyIdentifier”": "“16135551212”",
+                                "“partySubIdOrType”": "“DRIVING_LICENSE”",
+                                "“fspId”": "“1234”"
+                            },
+                            "merchantClassificationCode": "4321",
+                            "“name”": "“Justin Trudeau”",
+                            "“personalInfo”": {
+                                "“complexName”": {
+                                    "“firstName”": "“Justin”",
+                                    "“middleName”": "“Pierre”",
+                                    "“lastName”": "“Trudeau”"
+                                },
+                                "“dateOfBirth”": "“1971-12-25”"
+                            }
+                        },
+                        "“payer”": {
+                            "“partyIdType”": "“PERSONAL_ID”",
+                            "“partyIdentifier”": "“16135551212”",
+                            "“partySubIdOrType”": "“DRIVING_LICENSE”",
+                            "“fspId”": "“1234”"
+                        },
+                        "“amount”": {
+                            "“currency”": "“USD”",
+                            "“amount”": "“123.45”"
+                        },
+                        "“transactionType”": {
+                            "“scenario”": "“DEPOSIT”",
+                            "“subScenario”": "“locally defined sub-scenario”",
+                            "“initiator”": "“PAYEE”",
+                            "“initiatorType”": "“CONSUMER”",
+                            "“refundInfo”": {
+                                "“originalTransactionId”": "“b51ec534-ee48-4575-b6a9-ead2955b8069”",
+                                "“refundReason”": "“free text indicating reason for the refund”"
+                            },
+                            "“balanceOfPayments”": "“123”"
+                        },
+                        "“note”": "“Free-text memo”",
+                        "“geoCode”": {
+                            "“latitude”": "“+45.4215”",
+                            "“longitude”": "“+75.6972”"
+                        },
+                        "“authenticationType”": "“OTP”",
+                        "“expiration”": "“2016-05-24T08:38:08.699-04:00”",
+                        "extensionList": {
+                            "extension": [
+                                {
+                                    "“key”": "“errorDescription”",
+                                    "“value”": "“This is a more detailed error description”"
+                                },
+                                {
+                                    "“key”": "“errorDescription”",
+                                    "“value”": "“This is a more detailed error description”"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+
+        "/authorizations": {
+            "post": {
+              "description": "The HTTP request POST /authorizations is used to request the Payer to enter the applicable credentials in the PISP system.",
+              "summary": "/authorizations",
+              "tags": [
+                "authorizations"
+              ],
+              "operationId": "AuthorizationsByIDPost",
+              "produces": [
+                "application/json"
+              ],
+              "parameters": [
+                {
+                  "name": "body",
+                  "in": "body",
+                  "required": true,
+                  "schema": {
+                    "$ref": "#/definitions/AuthorizationsPostRequest"
+                  }
+                },
+                {
+                  "$ref": "#/parameters/Content-Length"
+                },
+                {
+                  "$ref": "#/parameters/Content-Type"
+                },
+                {
+                  "$ref": "#/parameters/Date"
+                },
+                {
+                  "$ref": "#/parameters/X-Forwarded-For"
+                },
+                {
+                  "$ref": "#/parameters/FSPIOP-Source"
+                },
+                {
+                  "$ref": "#/parameters/FSPIOP-Destination"
+                },
+                {
+                  "$ref": "#/parameters/FSPIOP-Encryption"
+                },
+                {
+                  "$ref": "#/parameters/FSPIOP-Signature"
+                },
+                {
+                  "$ref": "#/parameters/FSPIOP-URI"
+                },
+                {
+                  "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                }
+              ],
+              "x-examples": {
+                "application/json": {
+                  "authenticationType": "U2F",
+                  "retriesLeft": 1,
+                  "amount": {
+                    "currency": "USD",
+                    "amount": "18"
+                  },
+                  "transactionId": "2f169631-ef99-4cb1-96dc-91e8fc08f539",
+                  "transactionRequestId": "02e28448-3c05-4059-b5f7-d518d0a2d8ea",
+                  "quote": {
+                    "transferAmount": {
+                      "currency": "USD",
+                      "amount": "18"
+                    },
+                    "payeeReceiveAmount": {
+                      "currency": "USD",
+                      "amount": "0"
+                    },
+                    "payeeFspFee": {
+                      "currency": "USD",
+                      "amount": "0"
+                    },
+                    "payeeFspCommission": {
+                      "currency": "USD",
+                      "amount": "0"
+                    },
+                    "expiration": "2020-05-17T15:28:54.250Z",
+                    "geoCode": {
+                      "latitude": "string",
+                      "longitude": "string"
+                    },
+                    "ilpPacket": "string",
+                    "condition": "string",
+                    "extensionList": {
+                      "extension": [
+                        {
+                          "key": "string",
+                          "value": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              },
+              "responses": {
+                "202": {
+                  "$ref": "#/responses/Response202"
+                },
+                "400": {
+                  "$ref": "#/responses/ErrorResponse400"
+                },
+                "401": {
+                  "$ref": "#/responses/ErrorResponse401"
+                },
+                "403": {
+                  "$ref": "#/responses/ErrorResponse403"
+                },
+                "404": {
+                  "$ref": "#/responses/ErrorResponse404"
+                },
+                "405": {
+                  "$ref": "#/responses/ErrorResponse405"
+                },
+                "406": {
+                  "$ref": "#/responses/ErrorResponse406"
+                },
+                "501": {
+                  "$ref": "#/responses/ErrorResponse501"
+                },
+                "503": {
+                  "$ref": "#/responses/ErrorResponse503"
+                }
+              }
+            }
+          },     
+        
+        "/authorizations/{ID}": {
+            "get": {
+                "tags": [
+                    "authorizations",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "name": "authenticationType",
+                        "description": "a valid enumeration for the authentication type: OTP, QRCODE",
+                        "in": "query",
+                        "required": true,
+                        "type": "string",
+                        "enum": [
+                            "OTP",
+                            "QRCODE"
+                        ]
+                    },
+                    {
+                        "name": "retriesLeft",
+                        "description": "The number of retries left before the financial transaction is rejected",
+                        "in": "query",
+                        "required": true,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "amount",
+                        "description": "The transaction amount that will be withdrawn from the Payer’s account",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "currency",
+                        "description": "The transaction currency for the amount that will be withdrawn from the Payer’s account",
+                        "in": "query",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "$ref": "#/parameters/ID"
+                    },
+                    {
+                        "$ref": "#/parameters/Accept"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Length"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/Response200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "summary": "/authorizations/<ID>",
+                "description": "The HTTP request GET /authorizations/<ID> is used to request authorization for a specified transaction request. The <ID> in the URI should contain the transactionRequestId for which authorization is being requested."
+            },
+            "put": {
+                "tags": [
+                    "authorizations",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "schema": {
+                            "$ref": "#/definitions/AuthorizationsIDPutResponse"
+                        },
+                        "in": "body",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/ID"
+                    },
+                    {
+                        "$ref": "#/parameters/Accept"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Length"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/Response200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "AuthorizationsIDPutResponse",
+                "summary": "/authorizations/<ID>",
+                "description": "The callback PUT /authorizations/<ID> is used to inform the client of an authorization result for a transactionRequest. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request, or the <ID> that was used in the GET /transactionRequests/<ID>."
+            }
+        },
+        "/authorizations/{ID}/error": {
+            "put": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "authorizations",
+                    "sampled"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ID"
+                    },
+                    {
+                        "name": "body",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorInformationObject"
+                        },
+                        "in": "body",
+                        "required": true
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Length"
+                    },
+                    {
+                        "$ref": "#/parameters/Content-Type"
+                    },
+                    {
+                        "$ref": "#/parameters/Date"
+                    },
+                    {
+                        "$ref": "#/parameters/X-Forwarded-For"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Source"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Destination"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Encryption"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-Signature"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-URI"
+                    },
+                    {
+                        "$ref": "#/parameters/FSPIOP-HTTP-Method"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/responses/Response200"
+                    },
+                    "400": {
+                        "$ref": "#/responses/ErrorResponse400"
+                    },
+                    "401": {
+                        "$ref": "#/responses/ErrorResponse401"
+                    },
+                    "403": {
+                        "$ref": "#/responses/ErrorResponse403"
+                    },
+                    "404": {
+                        "$ref": "#/responses/ErrorResponse404"
+                    },
+                    "405": {
+                        "$ref": "#/responses/ErrorResponse405"
+                    },
+                    "406": {
+                        "$ref": "#/responses/ErrorResponse406"
+                    },
+                    "501": {
+                        "$ref": "#/responses/ErrorResponse501"
+                    },
+                    "503": {
+                        "$ref": "#/responses/ErrorResponse503"
+                    }
+                },
+                "operationId": "AuthorizationsErrorByID",
+                "summary": "/authorizations/<ID>/error",
+                "description": "If the server is unable to process the authorization message, the error callback PUT /authorizations/<ID>/error is used. The <ID> in the URI should contain the transactionRequestId that was used for the creation of the transaction request, or the <ID> that was used in the GET /transactionRequests/<ID>.",
+                "x-examples": {
+                    "application/json": {
+                        "“errorInformation”": {
+                            "“errorCode”": "“5100”",
+                            "“errorDescription”": "“This is an error description”",
+                            "extensionList": {
+                                "extension": [
+                                    {
+                                        "“key”": "“errorDescription”",
+                                        "“value”": "“This is a more detailed error description”"
+                                    },
+                                    {
+                                        "“key”": "“errorDescription”",
+                                        "“value”": "“This is a more detailed error description”"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Amount": {
+            "title": "Amount",
+            "description": "The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.",
+            "pattern": "^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$",
+            "type": "string"
+        },
+        "AmountType": {
+            "title": "AmountType",
+            "description": "Below are the allowed values for the enumeration AmountType - SEND Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. - RECEIVE Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver exclusive fees.",
+            "enum": [
+                "SEND",
+                "RECEIVE"
+            ],
+            "type": "string"
+        },
+
+        "AuthenticationType": {
+            "title": "AuthenticationTypeEnum",
+            "description": "Below are the allowed values for the enumeration AuthenticationType. - OTP One-time password generated by the Payer FSP. - QRCODE QR code used as One Time Password. - U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key.",
+            "enum": [
+              "OTP",
+              "QRCODE",
+              "U2F"
+            ],
+            "type": "string"          
+          },
+
+          "AuthenticationVal": {
+            "title": "AuthenticationVal",
+            "description": "Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.",
+            "pattern": "^\\d{3,10}$|^\\S{1,64}$",
+            "type": "string"
+          },
+      
+        "AuthorizationResponse": {
+            "title": "AuthorizationResponse",
+            "description": "Below are the allowed values for the enumeration - ENTERED Consumer entered the authentication value. - REJECTED Consumer rejected the transaction. - RESEND Consumer requested to resend the authentication value.",
+            "enum": [
+                "ENTERED",
+                "REJECTED",
+                "RESEND"
+            ],
+            "type": "string"
+        },
+        "BalanceOfPayments": {
+            "title": "BalanceOfPayments",
+            "description": "(BopCode) The API data type BopCode is a JSON String of 3 characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. https://www.imf.org/external/np/sta/bopcode/",
+            "pattern": "^[1-9]\\d{2}$",
+            "type": "string"
+        },
+        "BinaryString": {
+            "description": "The API data type BinaryString is a JSON String. The string is a base64url  encoding of a string of raw bytes, where padding (character ‘=’) is added at the end of the data if needed to ensure that the string is a multiple of 4 characters. The length restriction indicates the allowed number of characters.",
+            "pattern": "^[A-Za-z0-9-_]+[=]{0,2}$",
+            "type": "string"
+        },
+        "BinaryString32": {
+            "description": "The API data type BinaryString32 is a fixed size version of the API data type BinaryString, where the raw underlying data is always of 32 bytes. The data type BinaryString32 should not use a padding character as the size of the underlying data is fixed.",
+            "pattern": "^[A-Za-z0-9-_]{43}$",
+            "type": "string"
+        },
+        "BulkTransferState": {
+            "title": "BulkTransactionStateEnum",
+            "description": "Below are the allowed values for the enumeration - RECEIVED Payee FSP has received the bulk transfer from the Payer FSP. - PENDING Payee FSP has validated the bulk transfer. - ACCEPTED Payee FSP has accepted to process the bulk transfer. - PROCESSING Payee FSP has started to transfer fund to the Payees. - COMPLETED Payee FSP has completed transfer of funds to the Payees. - REJECTED Payee FSP has rejected to process the bulk transfer.",
+            "enum": [
+                "RECEIVED",
+                "PENDING",
+                "ACCEPTED",
+                "PROCESSING",
+                "COMPLETED",
+                "REJECTED"
+            ],
+            "type": "string"
+        },
+        "Code": {
+            "title": "Code",
+            "description": "Any code/token returned by the Payee FSP (TokenCode Type).",
+            "pattern": "^[0-9a-zA-Z]{4,32}$",
+            "type": "string"
+        },
+        "CorrelationId": {
+            "title": "CorrelationId",
+            "description": "Identifier that correlates all messages of the same sequence. The API data type UUID (Universally Unique Identifier) is a JSON String in canonical format, conforming to RFC 4122, that is restricted by a regular expression for interoperability reasons. An UUID is always 36 characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+            "type": "string"
+        },
+        "Currency": {
+            "title": "CurrencyEnum",
+            "description": "The currency codes defined in ISO 4217 as three-letter alphabetic codes are used as the standard naming representation for currencies.",
+            "maxLength": 3,
+            "minLength": 3,
+            "enum": [
+                "AED",
+                "AFN",
+                "ALL",
+                "AMD",
+                "ANG",
+                "AOA",
+                "ARS",
+                "AUD",
+                "AWG",
+                "AZN",
+                "BAM",
+                "BBD",
+                "BDT",
+                "BGN",
+                "BHD",
+                "BIF",
+                "BMD",
+                "BND",
+                "BOB",
+                "BRL",
+                "BSD",
+                "BTN",
+                "BWP",
+                "BYN",
+                "BZD",
+                "CAD",
+                "CDF",
+                "CHF",
+                "CLP",
+                "CNY",
+                "COP",
+                "CRC",
+                "CUC",
+                "CUP",
+                "CVE",
+                "CZK",
+                "DJF",
+                "DKK",
+                "DOP",
+                "DZD",
+                "EGP",
+                "ERN",
+                "ETB",
+                "EUR",
+                "FJD",
+                "FKP",
+                "GBP",
+                "GEL",
+                "GGP",
+                "GHS",
+                "GIP",
+                "GMD",
+                "GNF",
+                "GTQ",
+                "GYD",
+                "HKD",
+                "HNL",
+                "HRK",
+                "HTG",
+                "HUF",
+                "IDR",
+                "ILS",
+                "IMP",
+                "INR",
+                "IQD",
+                "IRR",
+                "ISK",
+                "JEP",
+                "JMD",
+                "JOD",
+                "JPY",
+                "KES",
+                "KGS",
+                "KHR",
+                "KMF",
+                "KPW",
+                "KRW",
+                "KWD",
+                "KYD",
+                "KZT",
+                "LAK",
+                "LBP",
+                "LKR",
+                "LRD",
+                "LSL",
+                "LYD",
+                "MAD",
+                "MDL",
+                "MGA",
+                "MKD",
+                "MMK",
+                "MNT",
+                "MOP",
+                "MRO",
+                "MUR",
+                "MVR",
+                "MWK",
+                "MXN",
+                "MYR",
+                "MZN",
+                "NAD",
+                "NGN",
+                "NIO",
+                "NOK",
+                "NPR",
+                "NZD",
+                "OMR",
+                "PAB",
+                "PEN",
+                "PGK",
+                "PHP",
+                "PKR",
+                "PLN",
+                "PYG",
+                "QAR",
+                "RON",
+                "RSD",
+                "RUB",
+                "RWF",
+                "SAR",
+                "SBD",
+                "SCR",
+                "SDG",
+                "SEK",
+                "SGD",
+                "SHP",
+                "SLL",
+                "SOS",
+                "SPL",
+                "SRD",
+                "STD",
+                "SVC",
+                "SYP",
+                "SZL",
+                "THB",
+                "TJS",
+                "TMT",
+                "TND",
+                "TOP",
+                "TRY",
+                "TTD",
+                "TVD",
+                "TWD",
+                "TZS",
+                "UAH",
+                "UGX",
+                "USD",
+                "UYU",
+                "UZS",
+                "VEF",
+                "VND",
+                "VUV",
+                "WST",
+                "XAF",
+                "XCD",
+                "XDR",
+                "XOF",
+                "XPF",
+                "YER",
+                "ZAR",
+                "ZMW",
+                "ZWD"
+            ],
+            "type": "string"
+        },
+
+        "Counter": {
+            "title": "Counter",
+            "$ref": "#/definitions/Integer",
+            "description": "Sequential counter used for cloning detection. Present only for U2F authentication."
+          },
+      
+        "Date": {
+            "title": "Date",
+            "description": "The API data type Date is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons. This format, as specified in ISO 8601, contains a date only. A more readable version of the format is yyyy-MM-dd. Examples - \"1982-05-23\", \"1987-08-05”",
+            "pattern": "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$",
+            "type": "string"
+        },
+        "DateOfBirth": {
+            "title": "DateofBirth (type Date)",
+            "description": "Date of Birth of the Party.",
+            "pattern": "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$",
+            "type": "string"
+        },
+        "DateTime": {
+            "title": "DateTime",
+            "description": "The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons. The format is according to ISO 8601, expressed in a combined date, time and time zone format. A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples -  \"2016-05-24T08:38:08.699-04:00\", \"2016-05-24T08:38:08.699Z\" (where Z indicates Zulu time zone, same as UTC).",
+            "pattern": "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:(\\.\\d{3}))(?:Z|[+-][01]\\d:[0-5]\\d)$",
+            "type": "string"
+        },
+        "ErrorCode": {
+            "title": "ErrorCode",
+            "description": "The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represents the specific error.",
+            "pattern": "^[1-9]\\d{3}$",
+            "type": "string"
+        },
+        "ErrorDescription": {
+            "title": "ErrorDescription",
+            "description": "Error description string.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "ExtensionKey": {
+            "title": "ExtensionKey",
+            "description": "Extension key.",
+            "maxLength": 32,
+            "minLength": 1,
+            "type": "string"
+        },
+        "ExtensionValue": {
+            "title": "ExtensionValue",
+            "description": "Extension value.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "FirstName": {
+            "title": "FirstName",
+            "description": "First name of the Party (Name Type).",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^(?!\\s*$)[\\w .,'-]{1,128}$",
+            "type": "string"
+        },
+        "FspId": {
+            "title": "FspId",
+            "description": "FSP identifier.",
+            "maxLength": 32,
+            "minLength": 1,
+            "type": "string"
+        },
+        "IlpCondition": {
+            "title": "IlpCondition",
+            "description": "Condition that must be attached to the transfer by the Payer.",
+            "maxLength": 48,
+            "pattern": "^[A-Za-z0-9-_]{43}$",
+            "type": "string"
+        },
+        "IlpFulfilment": {
+            "title": "IlpFulfilment",
+            "description": "Fulfilment that must be attached to the transfer by the Payee.",
+            "maxLength": 48,
+            "pattern": "^[A-Za-z0-9-_]{43}$",
+            "type": "string"
+        },
+        "IlpPacket": {
+            "title": "IlpPacket",
+            "description": "Information for recipient (transport layer information).",
+            "maxLength": 32768,
+            "minLength": 1,
+            "pattern": "^[A-Za-z0-9-_]+[=]{0,2}$",
+            "type": "string"
+        },
+        "Integer": {
+            "title": "Integer",
+            "description": "The API data type Integer is a JSON String consisting of digits only. Negative numbers and leading zeroes are not allowed. The data type is always limited to a specific number of digits.",
+            "pattern": "^[1-9]\\d*$",
+            "type": "string"
+        },
+        "LastName": {
+            "title": "LastName",
+            "description": "Last name of the Party (Name Type).",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^(?!\\s*$)[\\w .,'-]{1,128}$",
+            "type": "string"
+        },
+        "Latitude": {
+            "title": "Latitude",
+            "description": "The API data type Latitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.",
+            "pattern": "^(\\+|-)?(?:90(?:(?:\\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\\.[0-9]{1,6})?))$",
+            "type": "string"
+        },
+        "Longitude": {
+            "title": "Longitude",
+            "description": "The API data type Longitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.",
+            "pattern": "^(\\+|-)?(?:180(?:(?:\\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\\.[0-9]{1,6})?))$",
+            "type": "string"
+        },
+        "MerchantClassificationCode": {
+            "title": "MerchantClassificationCode",
+            "description": "A limited set of pre-defined numbers. This list would be a limited set of numbers identifying a set of popular merchant types like School Fees, Pubs and Restaurants, Groceries, etc.",
+            "pattern": "^[\\d]{1,4}$",
+            "type": "string"
+        },
+        "MiddleName": {
+            "title": "MiddleName",
+            "description": "Middle name of the Party (Name Type).",
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^(?!\\s*$)[\\w .,'-]{1,128}$",
+            "type": "string"
+        },
+        "Name": {
+            "title": "Name",
+            "description": "The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally not used in a name. Regular Expression - The regular expression for restricting the Name type is \"^(?!\\s*$)[\\w .,'-]{1,128}$\". The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,) and space characters ( ). Note -  In some programming languages, Unicode support must be specifically enabled. For example, if Java is used the flag UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.",
+            "pattern": "^(?!\\s*$)[\\w .,'-]{1,128}$",
+            "type": "string"
+        },
+        "Note": {
+            "title": "Note",
+            "description": "Memo assigned to transaction",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "OtpValue": {
+            "title": "OtpValue",
+            "description": "The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. Negative numbers are not allowed. One or more leading zeros are allowed.",
+            "pattern": "^\\d{3,10}$",
+            "type": "string"
+        },
+        "PartyIdentifier": {
+            "title": "PartyIdentifier",
+            "description": "Identifier of the Party.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "PartyIdType": {
+            "title": "PartyIdTypeEnum",
+            "description": "Below are the allowed values for the enumeration - MSISDN An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the ITU-T E.164 standard. Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix. - EMAIL An email is used as reference to a participant. The format of the email should be according to the informational RFC 3696. - PERSONAL_ID A personal identifier is used as reference to a participant. Examples of personal identification are passport number, birth certificate number, and national registration number. The identifier number is added in the PartyIdentifier element. The personal identifier type is added in the PartySubIdOrType element. - BUSINESS A specific Business (for example, an organization or a company) is used as reference to a participant. The BUSINESS identifier can be in any format. To make a transaction connected to a specific username or bill number in a Business, the PartySubIdOrType element should be used. - DEVICE A specific device (for example, a POS or ATM) ID connected to a specific business or organization is used as reference to a Party. For referencing a specific device under a specific business or organization, use the PartySubIdOrType element. - ACCOUNT_ID A bank account number or FSP account ID should be used as reference to a participant. The ACCOUNT_ID identifier can be in any format, as formats can greatly differ depending on country and FSP. - IBAN A bank account number or FSP account ID is used as reference to a participant. The IBAN identifier can consist of up to 34 alphanumeric characters and should be entered without whitespace. - ALIAS An alias is used as reference to a participant. The alias should be created in the FSP as an alternative reference to an account owner. Another example of an alias is a username in the FSP system. The ALIAS identifier can be in any format. It is also possible to use the PartySubIdOrType element for identifying an account under an Alias defined by the PartyIdentifier.",
+            "enum": [
+                "MSISDN",
+                "EMAIL",
+                "PERSONAL_ID",
+                "BUSINESS",
+                "DEVICE",
+                "ACCOUNT_ID",
+                "IBAN",
+                "ALIAS"
+            ],
+            "type": "string"
+        },
+        "PartyName": {
+            "title": "PartyName",
+            "description": "Name of the Party. Could be a real name or a nickname.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "PartySubIdOrType": {
+            "title": "PartySubIdOrType",
+            "description": "Either a sub-identifier of a PartyIdentifier, or a sub-type of the PartyIdType, normally a PersonalIdentifierType.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+        "PersonalIdentifierType": {
+            "title": "PersonalIdentifierType",
+            "description": "Below are the allowed values for the enumeration - PASSPORT A passport number is used as reference to a Party. - NATIONAL_REGISTRATION A national registration number is used as reference to a Party. - DRIVING_LICENSE A driving license is used as reference to a Party. - ALIEN_REGISTRATION An alien registration number is used as reference to a Party. - NATIONAL_ID_CARD A national ID card number is used as reference to a Party. - EMPLOYER_ID A tax identification number is used as reference to a Party. - TAX_ID_NUMBER A tax identification number is used as reference to a Party. - SENIOR_CITIZENS_CARD A senior citizens card number is used as reference to a Party. - MARRIAGE_CERTIFICATE A marriage certificate number is used as reference to a Party. - HEALTH_CARD A health card number is used as reference to a Party. - VOTERS_ID A voter’s identification number is used as reference to a Party. - UNITED_NATIONS An UN (United Nations) number is used as reference to a Party. - OTHER_ID Any other type of identification type number is used as reference to a Party.",
+            "enum": [
+                "PASSPORT",
+                "NATIONAL_REGISTRATION",
+                "DRIVING_LICENSE",
+                "ALIEN_REGISTRATION",
+                "NATIONAL_ID_CARD",
+                "EMPLOYER_ID",
+                "TAX_ID_NUMBER",
+                "SENIOR_CITIZENS_CARD",
+                "MARRIAGE_CERTIFICATE",
+                "HEALTH_CARD",
+                "VOTERS_ID",
+                "UNITED_NATIONS",
+                "OTHER_ID"
+            ],
+            "type": "string"
+        },
+        "QRCODE": {
+            "title": "QRCODE",
+            "description": "QR code used as One Time Password.",
+            "maxLength": 64,
+            "minLength": 1,
+            "type": "string"
+        },
+        "RefundReason": {
+            "title": "RefundReason",
+            "description": "Reason for the refund.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+        },
+
+        "RetriesLeft": {
+            "title": "RetriesLeft",
+            "$ref": "#/definitions/Integer",
+            "description": "RetriesLeft is the number of retries left before the financial transaction is rejected. It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected."
+          },      
+        
+        "TokenCode": {
+            "title": "TokenCode",
+            "description": "The API data type TokenCode is a JSON String between 4 and 32 characters, consisting of digits or upper or lowercase characters from a to z.",
+            "pattern": "^[0-9a-zA-Z]{4,32}$",
+            "type": "string"
+        },
+        "TransactionInitiator": {
+            "title": "TransactionInitiatorEnum",
+            "description": "Below are the allowed values for the enumeration - PAYER Sender of funds is initiating the transaction. The account to send from is either owned by the Payer or is connected to the Payer in some way. - PAYEE Recipient of the funds is initiating the transaction by sending a transaction request. The Payer must approve the transaction, either automatically by a pre-generated OTP or by pre-approval of the Payee, or by manually approving in his or her own Device.",
+            "enum": [
+                "PAYER",
+                "PAYEE"
+            ],
+            "type": "string"
+        },
+        "TransactionInitiatorType": {
+            "title": "TransactionInitiatorTypeEnum",
+            "description": "Below are the allowed values for the enumeration - CONSUMER Consumer is the initiator of the transaction. - AGENT Agent is the initiator of the transaction. - BUSINESS Business is the initiator of the transaction. - DEVICE Device is the initiator of the transaction.",
+            "enum": [
+                "CONSUMER",
+                "AGENT",
+                "BUSINESS",
+                "DEVICE"
+            ],
+            "type": "string"
+        },
+        "TransactionRequestState": {
+            "title": "TransactionRequestStateEnum",
+            "description": "Below are the allowed values for the enumeration - RECEIVED Payer FSP has received the transaction from the Payee FSP. - PENDING Payer FSP has sent the transaction request to the Payer. - ACCEPTED Payer has approved the transaction. - REJECTED Payer has rejected the transaction.",
+            "enum": [
+                "RECEIVED",
+                "PENDING",
+                "ACCEPTED",
+                "REJECTED"
+            ],
+            "type": "string"
+        },
+        "TransactionScenario": {
+            "title": "TransactionScenarioEnum",
+            "description": "Below are the allowed values for the enumeration - DEPOSIT Used for performing a Cash-In (deposit) transaction. In a normal scenario, electronic funds are transferred from a Business account to a Consumer account, and physical cash is given from the Consumer to the Business User. - WITHDRAWAL Used for performing a Cash-Out (withdrawal) transaction. In a normal scenario, electronic funds are transferred from a Consumer’s account to a Business account, and physical cash is given from the Business User to the Consumer. - TRANSFER Used for performing a P2P (Peer to Peer, or Consumer to Consumer) transaction. - PAYMENT Usually used for performing a transaction from a Consumer to a Merchant or Organization, but could also be for a B2B (Business to Business) payment. The transaction could be online for a purchase in an Internet store, in a physical store where both the Consumer and Business User are present, a bill payment, a donation, and so on. - REFUND Used for performing a refund of transaction.",
+            "enum": [
+                "DEPOSIT",
+                "WITHDRAWAL",
+                "TRANSFER",
+                "PAYMENT",
+                "REFUND"
+            ],
+            "type": "string"
+        },
+        "TransactionState": {
+            "title": "TransactionStateEnum",
+            "description": "Below are the allowed values for the enumeration - RECEIVED Payee FSP has received the transaction from the Payer FSP. - PENDING Payee FSP has validated the transaction. - COMPLETED Payee FSP has successfully performed the transaction. - REJECTED Payee FSP has failed to perform the transaction.",
+            "enum": [
+                "RECEIVED",
+                "PENDING",
+                "COMPLETED",
+                "REJECTED"
+            ],
+            "type": "string"
+        },
+        "TransactionSubScenario": {
+            "title": "TransactionSubScenario",
+            "description": "Possible sub-scenario, defined locally within the scheme (UndefinedEnum Type).",
+            "pattern": "^[A-Z_]{1,32}$",
+            "type": "string"
+        },
+        "TransferState": {
+            "title": "TransferStateEnum",
+            "description": "Below are the allowed values for the enumeration - RECEIVED Next ledger has received the transfer. - RESERVED Next ledger has reserved the transfer. - COMMITTED Next ledger has successfully performed the transfer. - ABORTED Next ledger has aborted the transfer due a rejection or failure to perform the transfer.",
+            "enum": [
+                "RECEIVED",
+                "RESERVED",
+                "COMMITTED",
+                "ABORTED"
+            ],
+            "type": "string"
+        },
+        "UndefinedEnum": {
+            "title": "UndefinedEnum",
+            "description": "The API data type UndefinedEnum is a JSON String consisting of 1 to 32 uppercase characters including an underscore character (_).",
+            "pattern": "^[A-Z_]{1,32}$",
+            "type": "string"
+        },
+
+        "U2F": {
+            "title": "U2F",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "U2F challenge-response, where payer FSP verifies if the response provided by end-user device matches the previously registered key."
+        },
+
+        "AuthenticationInfo": {
+            "title": "AuthenticationInfo",
+            "description": "Data model for the complex type AuthenticationInfo",
+            "required": [
+                "authentication",
+                "authenticationValue"
+            ],
+            "type": "object",
+            "properties": {
+                "authentication": {
+                    "type": "string"
+                },
+                "authenticationValue": {
+                    "type": "string"
+                }
+            }
+        },
+
+        "AuthenticationValue": {
+            "title": "AuthenticationValue",
+            "type": "object",
+            "description": "Data model for the complex type AuthenticationValue",
+            "properties": {
+              "authenticationVal": {
+                "$ref": "#/definitions/AuthenticationVal",
+                "description": "Authentication value."
+              },
+              "counter": {
+                "$ref": "#/definitions/Counter",
+                "description": "Sequential counter used for cloning detection. Present only for U2F authentication."
+              }
+            },
+            "required": [
+              "authenticationVal"
+            ]
+        },
+
+        "AuthorizationsPostRequest": {
+            "title": "AuthorizationsPostRequest",
+            "type": "object",
+            "description": "POST /authorizations Request object",
+            "properties": {
+              "authenticationType": {
+                "$ref": "#/definitions/AuthenticationType",
+                "description": "This value is a valid authentication type from the enumeration AuthenticationType(OTP or QR Code or U2F)."
+              },
+              "retriesLeft": {
+                "$ref": "#/definitions/RetriesLeft",
+                "description": "RetriesLeft is the number of retries left before the financial transaction is rejected. It must be expressed in the form of the data type Integer. retriesLeft=1 means that this is the last retry before the financial transaction is rejected."
+              },
+              "amount": {
+                "$ref": "#/definitions/Money",
+                "description": "This is the transaction amount that will be withdrawn from the Payer’s account."
+              },
+              "transactionId": {
+                "$ref": "#/definitions/CorrelationId",
+                "description": "Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process."
+              },
+              "transactionRequestId": {
+                "$ref": "#/definitions/CorrelationId",
+                "description": "The transactionRequestID, received from the POST /transactionRequests service earlier in the process."
+              },
+              "quote": {
+                "$ref": "#/definitions/QuotesIDPutResponse",
+                "description": "Quotes object"
+              }
+            },
+            "required": [
+              "authenticationType",
+              "retriesLeft",
+              "amount",
+              "currency",
+              "transactionId",
+              "transactionRequestId",
+              "quote"
+            ]
+          },    
+
+        "AuthorizationsIDPutResponse": {
+            "title": "AuthorizationsIDPutResponse",
+            "description": "PUT /authorizations/{ID} object",
+            "required": [
+                "responseType"
+            ],
+            "type": "object",
+            "properties": {
+                "authenticationInfo": {
+                    "$ref": "#/definitions/AuthenticationInfo",
+                    "description": "OTP or QR Code if entered, otherwise empty."
+                },
+                "responseType": {
+                    "description": "Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.",
+                    "type": "string"
+                }
+            }
+        },
+        "BulkQuotesPostRequest": {
+            "title": "BulkQuotesPostRequest",
+            "description": "POST /bulkQuotes object",
+            "required": [
+                "bulkQuoteId",
+                "payer",
+                "individualQuotes"
+            ],
+            "type": "object",
+            "properties": {
+                "bulkQuoteId": {
+                    "description": "Common ID between the FSPs for the bulk quote object, decided by the Payer FSP. The ID should be reused for resends of the same bulk quote. A new ID should be generated for each new bulk quote.",
+                    "type": "string"
+                },
+                "payer": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payer in the proposed financial transaction."
+                },
+                "geoCode": {
+                    "$ref": "#/definitions/GeoCode",
+                    "description": "Longitude and Latitude of the initiating Party. Can be used to detect fraud."
+                },
+                "expiration": {
+                    "description": "Expiration is optional to let the Payee FSP know when a quote no longer needs to be returned.",
+                    "type": "string"
+                },
+                "individualQuotes": {
+                    "description": "List of quotes elements.",
+                    "maxItems": 1000,
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IndividualQuote"
+                    }
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "BulkQuotesIDPutResponse": {
+            "title": "BulkQuotesIDPutResponse",
+            "description": "PUT /bulkQuotes/{ID} object",
+            "required": [
+                "expiration"
+            ],
+            "type": "object",
+            "properties": {
+                "individualQuoteResults": {
+                    "description": "Fees for each individual transaction, if any of them are charged per transaction.",
+                    "maxItems": 1000,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IndividualQuoteResult"
+                    }
+                },
+                "expiration": {
+                    "description": "Date and time until when the quotation is valid and can be honored when used in the subsequent transaction request.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "BulkTransfersPostRequest": {
+            "title": "BulkTransfersPostRequest",
+            "description": "POST /bulkTransfers object",
+            "required": [
+                "bulkTransferId",
+                "bulkQuoteId",
+                "payerFsp",
+                "payeeFsp",
+                "individualTransfers",
+                "expiration"
+            ],
+            "type": "object",
+            "properties": {
+                "bulkTransferId": {
+                    "description": "Common ID between the FSPs and the optional Switch for the bulk transfer object, decided by the Payer FSP. The ID should be reused for resends of the same bulk transfer. A new ID should be generated for each new bulk transfer.",
+                    "type": "string"
+                },
+                "bulkQuoteId": {
+                    "description": "ID of the related bulk quote.",
+                    "type": "string"
+                },
+                "payerFsp": {
+                    "description": "Payer FSP identifier.",
+                    "type": "string"
+                },
+                "payeeFsp": {
+                    "description": "Payee FSP identifier.",
+                    "type": "string"
+                },
+                "individualTransfers": {
+                    "description": "List of IndividualTransfer elements.",
+                    "maxItems": 1000,
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IndividualTransfer"
+                    }
+                },
+                "expiration": {
+                    "description": "Expiration time of the transfers.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "BulkTransfersIDPutResponse": {
+            "title": "BulkTransfersIDPutResponse",
+            "description": "PUT /bulkTransfers/{ID} object",
+            "required": [
+                "bulkTransferState"
+            ],
+            "type": "object",
+            "properties": {
+                "completedTimestamp": {
+                    "description": "Time and date when the bulk transaction was completed.",
+                    "type": "string"
+                },
+                "individualTransferResults": {
+                    "description": "List of IndividualTransferResult elements.",
+                    "maxItems": 1000,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/IndividualTransferResult"
+                    }
+                },
+                "bulkTransferState": {
+                    "description": "The state of the bulk transfer.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "ErrorInformation": {
+            "title": "ErrorInformation",
+            "description": "Data model for the complex type ErrorInformation.",
+            "required": [
+                "errorCode",
+                "errorDescription"
+            ],
+            "type": "object",
+            "properties": {
+                "errorCode": {
+                    "description": "Specific error number.",
+                    "type": "string"
+                },
+                "errorDescription": {
+                    "description": "Error description string.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional list of extensions, specific to deployment."
+                }
+            }
+        },
+        "ErrorInformationObject": {
+            "title": "ErrorInformationObject",
+            "description": "Data model for the complex type object that contains ErrorInformation.",
+            "required": [
+                "errorInformation"
+            ],
+            "type": "object",
+            "properties": {
+                "errorInformation": {
+                    "$ref": "#/definitions/ErrorInformation"
+                }
+            }
+        },
+        "ErrorInformationResponse": {
+            "title": "ErrorInformationResponse",
+            "description": "Data model for the complex type object that contains an optional element ErrorInformation used along with 4xx and 5xx responses.",
+            "type": "object",
+            "properties": {
+                "errorInformation": {
+                    "$ref": "#/definitions/ErrorInformation"
+                }
+            }
+        },
+        "Extension": {
+            "title": "Extension",
+            "description": "Data model for the complex type Extension",
+            "required": [
+                "key",
+                "value"
+            ],
+            "type": "object",
+            "properties": {
+                "key": {
+                    "description": "Extension key.",
+                    "type": "string"
+                },
+                "value": {
+                    "description": "Extension value.",
+                    "type": "string"
+                }
+            }
+        },
+        "ExtensionList": {
+            "title": "ExtensionList",
+            "description": "Data model for the complex type ExtensionList",
+            "required": [
+                "extension"
+            ],
+            "type": "object",
+            "properties": {
+                "extension": {
+                    "description": "Number of Extension elements",
+                    "maxItems": 16,
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Extension"
+                    }
+                }
+            }
+        },
+        "GeoCode": {
+            "title": "GeoCode",
+            "description": "Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.",
+            "required": [
+                "latitude",
+                "longitude"
+            ],
+            "type": "object",
+            "properties": {
+                "latitude": {
+                    "description": "Latitude of the Party.",
+                    "type": "string"
+                },
+                "longitude": {
+                    "description": "Longitude of the   Party.",
+                    "type": "string"
+                }
+            }
+        },
+        "IndividualQuote": {
+            "title": "IndividualQuote",
+            "description": "Data model for the complex type IndividualQuote.",
+            "required": [
+                "quoteId",
+                "transactionId",
+                "payee",
+                "amountType",
+                "amount",
+                "transactionType"
+            ],
+            "type": "object",
+            "properties": {
+                "quoteId": {
+                    "description": "Identifies quote message.",
+                    "type": "string"
+                },
+                "transactionId": {
+                    "description": "Identifies transaction message.",
+                    "type": "string"
+                },
+                "payee": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payee in the proposed financial transaction."
+                },
+                "amountType": {
+                    "description": "SEND for sendAmount, RECEIVE for receiveAmount.",
+                    "type": "string"
+                },
+                "amount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Depending on amountType - If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction. If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities."
+                },
+                "fees": {
+                    "$ref": "#/definitions/Money",
+                    "description": "The fees in the transaction. The fees element should be empty if fees should be non-disclosed. The fees element should be non-empty if fees should be disclosed."
+                },
+                "transactionType": {
+                    "$ref": "#/definitions/TransactionType",
+                    "description": "Type of transaction that the quote is requested for."
+                },
+                "note": {
+                    "description": "Memo that will be attached to the transaction.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "IndividualQuoteResult": {
+            "title": "IndividualQuoteResult",
+            "description": "Data model for the complex type IndividualQuoteResult.",
+            "required": [
+                "quoteId"
+            ],
+            "type": "object",
+            "properties": {
+                "quoteId": {
+                    "description": "Identifies quote message.",
+                    "type": "string"
+                },
+                "payee": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payee in the proposed financial transaction."
+                },
+                "transferAmount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Amount that the Payee FSP should receive."
+                },
+                "payeeReceiveAmount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Amount that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees."
+                },
+                "payeeFspFee": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Payee FSP’s part of the transaction fee."
+                },
+                "payeeFspCommission": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Transaction commission from the Payee FSP"
+                },
+                "ilpPacket": {
+                    "description": "The ILP Packet that must be attached to the transfer by the Payer.",
+                    "type": "string"
+                },
+                "condition": {
+                    "description": "The condition that must be attached to the transfer by the Payer.",
+                    "type": "string"
+                },
+                "errorInformation": {
+                    "$ref": "#/definitions/ErrorInformation",
+                    "description": "Error code, category description. Note - receiveAmount, payeeFspFee, payeeFspCommission, expiration, ilpPacket, condition should not be set if errorInformation is set."
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "IndividualTransfer": {
+            "title": "IndividualTransfer",
+            "description": "Data model for the complex type IndividualTransfer.",
+            "required": [
+                "transferId",
+                "transferAmount",
+                "ilpPacket",
+                "condition"
+            ],
+            "type": "object",
+            "properties": {
+                "transferId": {
+                    "description": "Identifies messages related to the same /transfers sequence.",
+                    "type": "string"
+                },
+                "transferAmount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Transaction amount to be sent."
+                },
+                "ilpPacket": {
+                    "description": "ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.",
+                    "type": "string"
+                },
+                "condition": {
+                    "description": "Condition that must be fulfilled to commit the transfer.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "IndividualTransferResult": {
+            "title": "IndividualTransferResult",
+            "description": "Data model for the complex type IndividualTransferResult.",
+            "required": [
+                "transferId"
+            ],
+            "type": "object",
+            "properties": {
+                "transferId": {
+                    "description": "Identifies messages related to the same /transfers sequence.",
+                    "type": "string"
+                },
+                "fulfilment": {
+                    "description": "Fulfilment of the condition specified with the transaction. Note - Either fulfilment or errorInformation should be set, not both.",
+                    "type": "string"
+                },
+                "errorInformation": {
+                    "$ref": "#/definitions/ErrorInformation",
+                    "description": "If transfer is REJECTED, error information may be provided. Note - Either fulfilment or errorInformation should be set, not both."
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "Money": {
+            "title": "Money",
+            "description": "Data model for the complex type Money.",
+            "required": [
+                "currency",
+                "amount"
+            ],
+            "type": "object",
+            "properties": {
+                "currency": {
+                    "description": "Currency of the amount.",
+                    "type": "string"
+                },
+                "amount": {
+                    "description": "Amount of Money.",
+                    "type": "string"
+                }
+            }
+        },
+        "ParticipantsTypeIDSubIDPostRequest": {
+            "title": "ParticipantsTypeIDSubIDPostRequest",
+            "description": "POST /participants/{Type}/{ID}/{SubId}, /participants/{Type}/{ID} object",
+            "required": [
+                "fspId"
+            ],
+            "type": "object",
+            "properties": {
+                "fspId": {
+                    "description": "FSP Identifier that the Party belongs to.",
+                    "type": "string"
+                },
+                "currency": {
+                    "description": "Indicate that the provided Currency is supported by the Party.",
+                    "type": "string"
+                }
+            }
+        },
+        "ParticipantsTypeIDPutResponse": {
+            "title": "ParticipantsTypeIDPutResponse",
+            "description": "PUT /participants/{Type}/{ID}/{SubId}, /participants/{Type}/{ID} object",
+            "type": "object",
+            "properties": {
+                "fspId": {
+                    "description": "FSP Identifier that the Party belongs to.",
+                    "type": "string"
+                }
+            }
+        },
+        "ParticipantsIDPutResponse": {
+            "title": "ParticipantsIDPutResponse",
+            "description": "PUT /participants/{ID} object",
+            "required": [
+                "partyList"
+            ],
+            "type": "object",
+            "properties": {
+                "partyList": {
+                    "description": "List of PartyResult elements that were either created or failed to be created.",
+                    "maxItems": 10000,
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PartyResult"
+                    }
+                },
+                "currency": {
+                    "description": "Indicate that the provided Currency was set to be supported by each successfully added PartyIdInfo.",
+                    "type": "string"
+                }
+            }
+        },
+        "ParticipantsPostRequest": {
+            "title": "ParticipantsPostRequest",
+            "description": "POST /participants object",
+            "required": [
+                "requestId",
+                "partyList"
+            ],
+            "type": "object",
+            "properties": {
+                "requestId": {
+                    "description": "The ID of the request, decided by the client. Used for identification of the callback from the server.",
+                    "type": "string"
+                },
+                "partyList": {
+                    "description": "List of PartyIdInfo elements that the client would like to update or create FSP information about.",
+                    "maxItems": 10000,
+                    "minItems": 1,
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/PartyIdInfo"
+                    }
+                },
+                "currency": {
+                    "description": "Indicate that the provided Currency is supported by each PartyIdInfo in the list.",
+                    "type": "string"
+                }
+            }
+        },
+        "Party": {
+            "title": "Party",
+            "description": "Data model for the complex type Party.",
+            "required": [
+                "partyIdInfo"
+            ],
+            "type": "object",
+            "properties": {
+                "partyIdInfo": {
+                    "$ref": "#/definitions/PartyIdInfo",
+                    "description": "Party Id type, id, sub ID or type, and FSP Id."
+                },
+                "merchantClassificationCode": {
+                    "description": "Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.",
+                    "type": "string"
+                },
+                "name": {
+                    "description": "Display name of the Party, could be a real name or a nick name.",
+                    "type": "string"
+                },
+                "personalInfo": {
+                    "$ref": "#/definitions/PartyPersonalInfo",
+                    "description": "Personal information used to verify identity of Party such as first, middle, last name and date of birth."
+                }
+            }
+        },
+        "PartyComplexName": {
+            "title": "PartyComplexName",
+            "description": "Data model for the complex type PartyComplexName.",
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "description": "Party’s first name.",
+                    "type": "string"
+                },
+                "middleName": {
+                    "description": "Party’s middle name.",
+                    "type": "string"
+                },
+                "lastName": {
+                    "description": "Party’s last name.",
+                    "type": "string"
+                }
+            }
+        },
+        "PartyIdInfo": {
+            "title": "PartyIdInfo",
+            "description": "Data model for the complex type PartyIdInfo.",
+            "required": [
+                "partyIdType",
+                "partyIdentifier"
+            ],
+            "type": "object",
+            "properties": {
+                "partyIdType": {
+                    "description": "Type of the identifier.",
+                    "type": "string"
+                },
+                "partyIdentifier": {
+                    "description": "An identifier for the Party.",
+                    "type": "string"
+                },
+                "partySubIdOrType": {
+                    "description": "A sub-identifier or sub-type for the Party.",
+                    "type": "string"
+                },
+                "fspId": {
+                    "description": "FSP ID (if known)",
+                    "type": "string"
+                }
+            }
+        },
+        "PartiesTypeIDPutResponse": {
+            "title": "PartiesTypeIDPutResponse",
+            "description": "PUT /parties/{Type}/{ID} object",
+            "required": [
+                "party"
+            ],
+            "type": "object",
+            "properties": {
+                "party": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information regarding the requested Party."
+                }
+            }
+        },
+        "PartyPersonalInfo": {
+            "title": "PartyPersonalInfo",
+            "description": "Data model for the complex type PartyPersonalInfo.",
+            "type": "object",
+            "properties": {
+                "complexName": {
+                    "$ref": "#/definitions/PartyComplexName",
+                    "description": "First, middle and last name for the Party."
+                },
+                "dateOfBirth": {
+                    "description": "Date of birth for the Party.",
+                    "type": "string"
+                }
+            }
+        },
+        "PartyResult": {
+            "title": "PartyResult",
+            "description": "Data model for the complex type PartyResult.",
+            "required": [
+                "partyId"
+            ],
+            "type": "object",
+            "properties": {
+                "partyId": {
+                    "$ref": "#/definitions/PartyIdInfo",
+                    "description": "Party Id type, id, sub ID or type, and FSP Id."
+                },
+                "errorInformation": {
+                    "$ref": "#/definitions/ErrorInformation",
+                    "description": "If the Party failed to be added, error information should be provided. Otherwise, this parameter should be empty to indicate success."
+                }
+            }
+        },
+        "QuotesPostRequest": {
+            "title": "QuotesPostRequest",
+            "description": "POST /quotes object",
+            "required": [
+                "quoteId",
+                "transactionId",
+                "payee",
+                "payer",
+                "amountType",
+                "amount",
+                "transactionType"
+            ],
+            "type": "object",
+            "properties": {
+                "quoteId": {
+                    "description": "Common ID between the FSPs for the quote object, decided by the Payer FSP. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.",
+                    "type": "string"
+                },
+                "transactionId": {
+                    "description": "Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.",
+                    "type": "string"
+                },
+                "transactionRequestId": {
+                    "description": "Identifies an optional previously-sent transaction request.",
+                    "type": "string"
+                },
+                "payee": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payee in the proposed financial transaction."
+                },
+                "payer": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payer in the proposed financial transaction."
+                },
+                "amountType": {
+                    "description": "SEND for send amount, RECEIVE for receive amount.",
+                    "type": "string"
+                },
+                "amount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Depending on amountType. If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction. If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities."
+                },
+                "fees": {
+                    "$ref": "#/definitions/Money",
+                    "description": "The fees in the transaction. The fees element should be empty if fees should be non-disclosed. The fees element should be non-empty if fees should be disclosed."
+                },
+                "transactionType": {
+                    "$ref": "#/definitions/TransactionType",
+                    "description": "Type of transaction for which the quote is requested."
+                },
+                "geoCode": {
+                    "$ref": "#/definitions/GeoCode",
+                    "description": "Longitude and Latitude of the initiating Party. Can be used to detect fraud."
+                },
+                "note": {
+                    "description": "A memo that will be attached to the transaction.",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "Expiration is optional. It can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, and Merchant to know that their request has a time limit.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "QuotesIDPutResponse": {
+            "title": "QuotesIDPutResponse",
+            "description": "PUT /quotes/{ID} object",
+            "required": [
+                "transferAmount",
+                "expiration",
+                "ilpPacket",
+                "condition"
+            ],
+            "type": "object",
+            "properties": {
+                "transferAmount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "The amount of money that the Payee FSP should receive."
+                },
+                "payeeReceiveAmount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees."
+                },
+                "payeeFspFee": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Payee FSP’s part of the transaction fee."
+                },
+                "payeeFspCommission": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Transaction commission from the Payee FSP."
+                },
+                "expiration": {
+                    "description": "Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.",
+                    "type": "string"
+                },
+                "geoCode": {
+                    "$ref": "#/definitions/GeoCode",
+                    "description": "Longitude and Latitude of the Payee. Can be used to detect fraud."
+                },
+                "ilpPacket": {
+                    "description": "The ILP Packet that must be attached to the transfer by the Payer.",
+                    "type": "string"
+                },
+                "condition": {
+                    "description": "The condition that must be attached to the transfer by the Payer.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "Refund": {
+            "title": "Refund",
+            "description": "Data model for the complex type Refund.",
+            "required": [
+                "originalTransactionId"
+            ],
+            "type": "object",
+            "properties": {
+                "originalTransactionId": {
+                    "description": "Reference to the original transaction ID that is requested to be refunded.",
+                    "type": "string"
+                },
+                "refundReason": {
+                    "description": "Free text indicating the reason for the refund.",
+                    "type": "string"
+                }
+            }
+        },
+        "Status": {
+            "title": "Status",
+            "description": "Data model for the api status.",
+            "type": "object",
+            "properties": {
+                "status": {
+                    "description": "The return status, usually \"OK\"",
+                    "type": "string"
+                },
+                "uptime": {
+                    "description": "The amount of time in seconds that the server has been up for.",
+                    "type": "number"
+                },
+                "startTime": {
+                    "description": "The UTC time that the server started up",
+                    "type": "string"
+                },
+                "versionNumber": {
+                    "description": "Current version of the API",
+                    "type": "string"
+                },
+                "services": {
+                    "description": "An list of the statuses of services that the API requires",
+                    "type": "array",
+                    "items": {}
+                }
+            }
+        },
+        "Transaction": {
+            "title": "Transaction",
+            "description": "Data model for the complex type Transaction. The Transaction type is used to carry end-to-end data between the Payer FSP and the Payee FSP in the ILP Packet. Both the transactionId and the quoteId in the data model are decided by the Payer FSP in the POST /quotes.",
+            "required": [
+                "transactionId",
+                "quoteId",
+                "payee",
+                "payer",
+                "amount",
+                "transactionType"
+            ],
+            "type": "object",
+            "properties": {
+                "transactionId": {
+                    "description": "ID of the transaction, the ID is decided by the Payer FSP during the creation of the quote.",
+                    "type": "string"
+                },
+                "quoteId": {
+                    "description": "ID of the quote, the ID is decided by the Payer FSP during the creation of the quote.",
+                    "type": "string"
+                },
+                "payee": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payee in the proposed financial transaction."
+                },
+                "payer": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payer in the proposed financial transaction."
+                },
+                "amount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Transaction amount to be sent."
+                },
+                "transactionType": {
+                    "$ref": "#/definitions/TransactionType",
+                    "description": "Type of the transaction."
+                },
+                "note": {
+                    "description": "Memo associated to the transaction, intended to the Payee.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "TransactionRequestsIDPutResponse": {
+            "title": "TransactionRequestsIDPutResponse",
+            "description": "PUT /transactionRequests/{ID} object",
+            "required": [
+                "transactionRequestState"
+            ],
+            "type": "object",
+            "properties": {
+                "transactionId": {
+                    "description": "Identifies a related transaction (if a transaction has been created).",
+                    "type": "string"
+                },
+                "transactionRequestState": {
+                    "description": "State of the transaction request.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "TransactionsIDPutResponse": {
+            "title": "TransactionsIDPutResponse",
+            "description": "PUT /transactions/{ID} object",
+            "required": [
+                "transactionState"
+            ],
+            "type": "object",
+            "properties": {
+                "completedTimestamp": {
+                    "description": "Time and date when the transaction was completed.",
+                    "type": "string"
+                },
+                "transactionState": {
+                    "description": "State of the transaction.",
+                    "type": "string"
+                },
+                "code": {
+                    "description": "Optional redemption information provided to Payer after transaction has been completed.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "TransactionType": {
+            "title": "TransactionType",
+            "description": "Data model for the complex type TransactionType.",
+            "required": [
+                "scenario",
+                "initiator",
+                "initiatorType"
+            ],
+            "type": "object",
+            "properties": {
+                "scenario": {
+                    "description": "Deposit, withdrawal, refund, …",
+                    "type": "string"
+                },
+                "subScenario": {
+                    "description": "Possible sub-scenario, defined locally within the scheme.",
+                    "type": "string"
+                },
+                "initiator": {
+                    "description": "Who is initiating the transaction - Payer or Payee",
+                    "type": "string"
+                },
+                "initiatorType": {
+                    "description": "Consumer, agent, business, …",
+                    "type": "string"
+                },
+                "refundInfo": {
+                    "$ref": "#/definitions/Refund",
+                    "description": "Extra information specific to a refund scenario. Should only be populated if scenario is REFUND"
+                },
+                "balanceOfPayments": {
+                    "description": "Balance of Payments code.",
+                    "type": "string"
+                }
+            }
+        },
+        "TransfersPostRequest": {
+            "title": "TransfersPostRequest",
+            "description": "POST /transfers Request object",
+            "required": [
+                "transferId",
+                "payeeFsp",
+                "payerFsp",
+                "amount",
+                "ilpPacket",
+                "condition",
+                "expiration"
+            ],
+            "type": "object",
+            "properties": {
+                "transferId": {
+                    "description": "The common ID between the FSPs and the optional Switch for the transfer object, decided by the Payer FSP. The ID should be reused for resends of the same transfer. A new ID should be generated for each new transfer.",
+                    "type": "string"
+                },
+                "payeeFsp": {
+                    "description": "Payee FSP in the proposed financial transaction.",
+                    "type": "string"
+                },
+                "payerFsp": {
+                    "description": "Payer FSP in the proposed financial transaction.",
+                    "type": "string"
+                },
+                "amount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "The transfer amount to be sent."
+                },
+                "ilpPacket": {
+                    "description": "The ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.",
+                    "type": "string"
+                },
+                "condition": {
+                    "description": "The condition that must be fulfilled to commit the transfer.",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "Expiration can be set to get a quick failure expiration of the transfer. The transfer should be rolled back if no fulfilment is delivered before this time.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "TransactionRequestsPostRequest": {
+            "title": "TransactionRequestsPostRequest",
+            "description": "POST /transactionRequests object",
+            "required": [
+                "transactionRequestId",
+                "payee",
+                "payer",
+                "amount",
+                "transactionType"
+            ],
+            "type": "object",
+            "properties": {
+                "transactionRequestId": {
+                    "description": "Common ID between the FSPs for the transaction request object, decided by the Payee FSP. The ID should be reused for resends of the same transaction request. A new ID should be generated for each new transaction request.",
+                    "type": "string"
+                },
+                "payee": {
+                    "$ref": "#/definitions/Party",
+                    "description": "Information about the Payee in the proposed financial transaction."
+                },
+                "payer": {
+                    "$ref": "#/definitions/PartyIdInfo",
+                    "description": "Information about the Payer type, id, sub-type/id, FSP Id in the proposed financial transaction."
+                },
+                "amount": {
+                    "$ref": "#/definitions/Money",
+                    "description": "Requested amount to be transferred from the Payer to Payee."
+                },
+                "transactionType": {
+                    "$ref": "#/definitions/TransactionType",
+                    "description": "Type of transaction."
+                },
+                "note": {
+                    "description": "Reason for the transaction request, intended to the Payer.",
+                    "type": "string"
+                },
+                "geoCode": {
+                    "$ref": "#/definitions/GeoCode",
+                    "description": "Longitude and Latitude of the initiating Party. Can be used to detect fraud."
+                },
+                "authenticationType": {
+                    "description": "OTP or QR Code, otherwise empty.",
+                    "type": "string"
+                },
+                "expiration": {
+                    "description": "Can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, Merchant to know that their request has a time limit.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        },
+        "TransfersIDPutResponse": {
+            "title": "TransfersIDPutResponse",
+            "description": "PUT /transfers/{ID} object",
+            "required": [
+                "transferState"
+            ],
+            "type": "object",
+            "properties": {
+                "fulfilment": {
+                    "description": "Fulfilment of the condition specified with the transaction. Mandatory if transfer has completed successfully.",
+                    "type": "string"
+                },
+                "completedTimestamp": {
+                    "description": "Time and date when the transaction was completed.",
+                    "type": "string"
+                },
+                "transferState": {
+                    "description": "State of the transfer.",
+                    "type": "string"
+                },
+                "extensionList": {
+                    "$ref": "#/definitions/ExtensionList",
+                    "description": "Optional extension, specific to deployment."
+                }
+            }
+        }
+    },
+    "parameters": {
+        "Accept": {
+            "name": "accept",
+            "description": "The Accept header field indicates the version of the API the client would like the server to use.",
+            "in": "header",
+            "required": true,
+            "type": "string"
+        },
+        "Content-Length": {
+            "name": "content-length",
+            "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body. Note - The API supports a maximum size of 5242880 bytes (5 Megabytes)",
+            "in": "header",
+            "required": false,
+            "type": "integer"
+        },
+        "Content-Type": {
+            "name": "content-type",
+            "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+            "in": "header",
+            "required": true,
+            "type": "string"
+        },
+        "Date": {
+            "name": "date",
+            "description": "The Date header field indicates the date when the request was sent.",
+            "in": "header",
+            "required": true,
+            "type": "string"
+        },
+        "X-Forwarded-For": {
+            "name": "x-forwarded-for",
+            "description": "The X-Forwarded-For header field is an unofficially accepted standard used for informational purposes of the originating client IP address, as a request might pass multiple proxies, firewalls, and so on. Multiple X-Forwarded-For values as in the example shown here should be expected and supported by implementers of the API. Note - An alternative to X-Forwarded-For is defined in RFC 7239. However, to this point RFC 7239 is less-used and supported than X-Forwarded-For.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+        },
+        "FSPIOP-Source": {
+            "name": "fspiop-source",
+            "description": "The FSPIOP-Source header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. The field should be set by the original sender of the request. Required for routing and signature verification (see header field FSPIOP-Signature).",
+            "in": "header",
+            "required": true,
+            "type": "string"
+        },
+        "FSPIOP-Destination": {
+            "name": "fspiop-destination",
+            "description": "The FSPIOP-Destination header field is a non-HTTP standard field used by the API for HTTP header based routing of requests and responses to the destination. The field should be set by the original sender of the request (if known), so that any entities between the client and the server do not need to parse the payload for routing purposes.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+        },
+        "FSPIOP-Encryption": {
+            "name": "fspiop-encryption",
+            "description": "The FSPIOP-Encryption header field is a non-HTTP standard field used by the API for applying end-to-end encryption of the request.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+        },
+        "FSPIOP-Signature": {
+            "name": "fspiop-signature",
+            "description": "The FSPIOP-Signature header field is a non-HTTP standard field used by the API for applying an end-to-end request signature.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+        },
+        "FSPIOP-URI": {
+            "name": "fspiop-uri",
+            "description": "The FSPIOP-URI header field is a non-HTTP standard field used by the API for signature verification, should contain the service URI. Required if signature verification is used, for more information see API Signature document.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+        },
+        "FSPIOP-HTTP-Method": {
+            "name": "fspiop-http-method",
+            "description": "The FSPIOP-HTTP-Method header field is a non-HTTP standard field used by the API for signature verification, should contain the service HTTP method. Required if signature verification is used, for more information see API Signature document.",
+            "in": "header",
+            "required": false,
+            "type": "string"
+        },
+        "ID": {
+            "name": "ID",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        },
+        "Type": {
+            "name": "Type",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        },
+        "SubId": {
+            "name": "SubId",
+            "in": "path",
+            "required": true,
+            "type": "string"
+        }
+    },
+    "responses": {
+        "ResponseHealth200": {
+            "description": "OK",
+            "schema": {
+                "$ref": "#/definitions/Status"
+            }
+        },
+        "Response200": {
+            "description": "OK"
+        },
+        "Response202": {
+            "description": "Accepted"
+        },
+        "ErrorResponse400": {
+            "description": "Bad Request - The application cannot process the request; for example, due to malformed syntax or the payload exceeded size restrictions.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse401": {
+            "description": "Unauthorized - The request requires authentication in order to be processed.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse403": {
+            "description": "Forbidden - The request was denied and will be denied in the future.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse404": {
+            "description": "Not Found - The resource specified in the URI was not found.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse405": {
+            "description": "Method Not Allowed - An unsupported HTTP method for the request was used.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse406": {
+            "description": "Not acceptable - The server is not capable of generating content according to the Accept headers sent in the request. Used in the API to indicate that the server does not support the version that the client is requesting.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse501": {
+            "description": "Not Implemented - The server does not support the requested service. The client should not retry.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        },
+        "ErrorResponse503": {
+            "description": "Service Unavailable - The server is currently unavailable to accept any new service requests. This should be a temporary state, and the client should retry within a reasonable time frame.",
+            "headers": {
+                "Content-Length": {
+                    "description": "The Content-Length header field indicates the anticipated size of the payload body. Only sent if there is a body.",
+                    "type": "integer"
+                },
+                "Content-Type": {
+                    "description": "The Content-Type header indicates the specific version of the API used to send the payload body.",
+                    "type": "string"
+                }
+            },
+            "schema": {
+                "$ref": "#/definitions/ErrorInformationResponse"
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Updated Swagger definition so that POST /authorizations request from the Payer DFSP contains transaction details and Quote response object.
- Extended enumeration for authentication types to include U2F
- As per [[EXTERNAL] Mojaloop: PISP Credit Transactions ](https://docs.google.com/document/d/17rLpCPM2NY-i4oKGxhlBMbQahGY0k83rij2EOiU_OR4/edit#heading=h.6bad58fzwcgn) modified AuthenticationValue and AuthenticationType.

- We can not raise a PR for mojaloop-specification repo, so provided links to the changes under section `PISP changes in other repos`