### PR TITLE
Updated services to handle GET party accounts.

### DIFF
--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -278,7 +278,7 @@ services:
       start_period: 40s
       interval: 30s
 
-## DFSP A
+  ## DFSP A
   dfspa-backend:
     image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
     container_name: dfspa-backend
@@ -293,7 +293,7 @@ services:
       - "dfspa-scheme-adapter:172.17.0.1"
 
   dfspa-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v0.1.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v0.2.0-pisp"
     container_name: dsfpa-scheme-adapter
     env_file: ./dfsp_a/dfsp_a_scheme_adapter.env
     volumes:
@@ -349,7 +349,7 @@ services:
       - "dfspb-scheme-adapter:172.17.0.1"
 
   dfspb-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v0.1.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v0.2.0-pisp"
     container_name: dfspb-scheme-adapter
     env_file: ./dfsp_b/dfsp_b_scheme_adapter.env
     volumes:
@@ -403,7 +403,7 @@ services:
       - "pisp-scheme-adapter:172.17.0.1"
 
   pisp-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v0.1.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v0.2.0-pisp"
     container_name: pisp-scheme-adapter
     env_file: ./pisp/pisp_scheme_adapter.env
     volumes:

--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -227,7 +227,7 @@ services:
        - ./docker/wait4:/opt/central-settlement/wait4
 
   account-lookup-service:
-    image: mojaloop/account-lookup-service:v0.0.4-pisp
+    image: mojaloop/account-lookup-service:v10.3.0.0-pisp
     container_name: account-lookup-service
     command: sh -c "/opt/account-lookup-service/wait4/wait4.js account-lookup-service && npm run migrate && node src/index.js server"
     ports:
@@ -280,7 +280,7 @@ services:
 
   ## DFSP A
   dfspa-backend:
-    image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
+    image: "mojaloop/mojaloop-simulator:v9.4.1.0-pisp"
     container_name: dfspa-backend
     env_file: ./dfsp_a/dfsp_a_backend.env
     volumes:
@@ -293,7 +293,7 @@ services:
       - "dfspa-scheme-adapter:172.17.0.1"
 
   dfspa-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v0.2.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v9.4.11.0-pisp"
     container_name: dsfpa-scheme-adapter
     env_file: ./dfsp_a/dfsp_a_scheme_adapter.env
     volumes:
@@ -336,7 +336,7 @@ services:
 
   ## DFSP B
   dfspb-backend:
-    image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
+    image: "mojaloop/mojaloop-simulator:v9.4.1.0-pisp"
     container_name: dfspb-backend
     env_file: ./dfsp_b/dfsp_b_backend.env
     volumes:
@@ -349,7 +349,7 @@ services:
       - "dfspb-scheme-adapter:172.17.0.1"
 
   dfspb-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v0.2.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v9.4.11.0-pisp"
     container_name: dfspb-scheme-adapter
     env_file: ./dfsp_b/dfsp_b_scheme_adapter.env
     volumes:
@@ -392,7 +392,7 @@ services:
 
  ## PISP
   pisp-backend:
-    image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
+    image: "mojaloop/mojaloop-simulator:v9.4.1.0-pisp"
     container_name: pisp-backend
     env_file: ./pisp/pisp_backend.env
     ports:
@@ -403,7 +403,7 @@ services:
       - "pisp-scheme-adapter:172.17.0.1"
 
   pisp-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v0.2.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v9.4.11.0-pisp"
     container_name: pisp-scheme-adapter
     env_file: ./pisp/pisp_scheme_adapter.env
     volumes:

--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -227,7 +227,7 @@ services:
        - ./docker/wait4:/opt/central-settlement/wait4
 
   account-lookup-service:
-    image: mojaloop/account-lookup-service:v10.3.0.0-pisp
+    image: mojaloop/account-lookup-service:v10.3.0.2-pisp
     container_name: account-lookup-service
     command: sh -c "/opt/account-lookup-service/wait4/wait4.js account-lookup-service && npm run migrate && node src/index.js server"
     ports:
@@ -280,7 +280,7 @@ services:
 
   ## DFSP A
   dfspa-backend:
-    image: "mojaloop/mojaloop-simulator:v9.4.1.0-pisp"
+    image: "mojaloop/mojaloop-simulator:v9.4.1.1-pisp"
     container_name: dfspa-backend
     env_file: ./dfsp_a/dfsp_a_backend.env
     volumes:
@@ -293,7 +293,7 @@ services:
       - "dfspa-scheme-adapter:172.17.0.1"
 
   dfspa-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v9.4.11.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v9.4.11.1-pisp"
     container_name: dsfpa-scheme-adapter
     env_file: ./dfsp_a/dfsp_a_scheme_adapter.env
     volumes:
@@ -336,7 +336,7 @@ services:
 
   ## DFSP B
   dfspb-backend:
-    image: "mojaloop/mojaloop-simulator:v9.4.1.0-pisp"
+    image: "mojaloop/mojaloop-simulator:v9.4.1.1-pisp"
     container_name: dfspb-backend
     env_file: ./dfsp_b/dfsp_b_backend.env
     volumes:
@@ -349,7 +349,7 @@ services:
       - "dfspb-scheme-adapter:172.17.0.1"
 
   dfspb-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v9.4.11.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v9.4.11.1-pisp"
     container_name: dfspb-scheme-adapter
     env_file: ./dfsp_b/dfsp_b_scheme_adapter.env
     volumes:
@@ -392,7 +392,7 @@ services:
 
  ## PISP
   pisp-backend:
-    image: "mojaloop/mojaloop-simulator:v9.4.1.0-pisp"
+    image: "mojaloop/mojaloop-simulator:v9.4.1.1-pisp"
     container_name: pisp-backend
     env_file: ./pisp/pisp_backend.env
     ports:
@@ -403,7 +403,7 @@ services:
       - "pisp-scheme-adapter:172.17.0.1"
 
   pisp-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v9.4.11.0-pisp"
+    image: "mojaloop/sdk-scheme-adapter:v9.4.11.1-pisp"
     container_name: pisp-scheme-adapter
     env_file: ./pisp/pisp_scheme_adapter.env
     volumes:

--- a/docker-local/docker-compose.yml
+++ b/docker-local/docker-compose.yml
@@ -227,7 +227,7 @@ services:
        - ./docker/wait4:/opt/central-settlement/wait4
 
   account-lookup-service:
-    image: mojaloop/account-lookup-service:v10.1.0
+    image: mojaloop/account-lookup-service:v0.0.4-pisp
     container_name: account-lookup-service
     command: sh -c "/opt/account-lookup-service/wait4/wait4.js account-lookup-service && npm run migrate && node src/index.js server"
     ports:
@@ -280,7 +280,7 @@ services:
 
 ## DFSP A
   dfspa-backend:
-    image: "mojaloop/mojaloop-simulator:v9.4.1"
+    image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
     container_name: dfspa-backend
     env_file: ./dfsp_a/dfsp_a_backend.env
     volumes:
@@ -293,7 +293,7 @@ services:
       - "dfspa-scheme-adapter:172.17.0.1"
 
   dfspa-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v9.4.11"
+    image: "mojaloop/sdk-scheme-adapter:v0.1.0-pisp"
     container_name: dsfpa-scheme-adapter
     env_file: ./dfsp_a/dfsp_a_scheme_adapter.env
     volumes:
@@ -336,7 +336,7 @@ services:
 
   ## DFSP B
   dfspb-backend:
-    image: "mojaloop/mojaloop-simulator:v9.4.1"
+    image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
     container_name: dfspb-backend
     env_file: ./dfsp_b/dfsp_b_backend.env
     volumes:
@@ -349,7 +349,7 @@ services:
       - "dfspb-scheme-adapter:172.17.0.1"
 
   dfspb-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v9.4.11"
+    image: "mojaloop/sdk-scheme-adapter:v0.1.0-pisp"
     container_name: dfspb-scheme-adapter
     env_file: ./dfsp_b/dfsp_b_scheme_adapter.env
     volumes:
@@ -392,7 +392,7 @@ services:
 
  ## PISP
   pisp-backend:
-    image: "mojaloop/mojaloop-simulator:v9.4.1"
+    image: "mojaloop/mojaloop-simulator:v0.1.0-pisp"
     container_name: pisp-backend
     env_file: ./pisp/pisp_backend.env
     ports:
@@ -403,7 +403,7 @@ services:
       - "pisp-scheme-adapter:172.17.0.1"
 
   pisp-scheme-adapter:
-    image: "mojaloop/sdk-scheme-adapter:v9.4.11"
+    image: "mojaloop/sdk-scheme-adapter:v0.1.0-pisp"
     container_name: pisp-scheme-adapter
     env_file: ./pisp/pisp_scheme_adapter.env
     volumes:

--- a/docker-local/docker/account-lookup-service/default.json
+++ b/docker-local/docker/account-lookup-service/default.json
@@ -24,6 +24,10 @@
       "expiresIn": 180000,
       "generateTimeout": 30000
     },
+    "ERROR_HANDLING": {
+      "includeCauseExtension": false,
+      "truncateExtensions": true
+    },
     "SWITCH_ENDPOINT": "http://central-ledger:3001",
     "INSTRUMENTATION": {
       "METRICS": {
@@ -38,6 +42,13 @@
             "serviceName": "account-lookup-service"
           }
         }
+      }
+    },
+    "ENDPOINT_SECURITY":{
+      "JWS": {
+        "JWS_SIGN": false,
+        "FSPIOP_SOURCE_TO_SIGN": "switch",
+        "JWS_SIGNING_KEY_PATH": "secrets/jwsSigningKey.key"
       }
     }
   }

--- a/docker-local/postman/PISP.postman_collection.json.postman_collection.json
+++ b/docker-local/postman/PISP.postman_collection.json.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a9e5e624-ed85-4861-bf83-99a853328454",
+		"_postman_id": "4782e366-cbc6-45c0-b9c4-557042912b53",
 		"name": "PISP.postman_collection.json",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -41,7 +41,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"displayName\": \"Alice Alpaca\",\n    \"firstName\": \"Alice\",\n    \"middleName\": \"K\",\n    \"lastName\": \"Alpaca\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"123456789\"\n}",
+							"raw": "{\n    \"displayName\": \"Alice Alpaca\",\n    \"firstName\": \"Alice\",\n    \"middleName\": \"K\",\n    \"lastName\": \"Alpaca\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"123456789\",\n    \"accounts\": [\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"savings\",\n\t\t  \"address\": \"moja.amber.53451233-b82a5456a-4fa9-838b-123456789\"\n\t\t},\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"checkings\",\n\t\t  \"address\": \"moja.amber.8f027046-b8236345a-4fa9-838b-123456789\"\n\t\t}\n\t]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -88,7 +88,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"displayName\": \"Bob Babirusa\",\n    \"firstName\": \"Bob\",\n    \"middleName\": \"O\",\n    \"lastName\": \"Babirusa\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"987654321\"\n}",
+							"raw": "{\n    \"displayName\": \"Bob Babirusa\",\n    \"firstName\": \"Bob\",\n    \"middleName\": \"O\",\n    \"lastName\": \"Babirusa\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"987654321\",\n    \"accounts\": [\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"savings\",\n\t\t  \"address\": \"moja.burgundy.76542756-f49gk439f-6a5f-543d-987654321\"\n\t\t},\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"checkings\",\n\t\t  \"address\": \"moja.burgundy.43638980-f49gk439f-6a5f-543d-987654321\"\n\t\t}\n\t]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -726,7 +726,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:5002//requestToPayTransfer",
+							"raw": "localhost:5002/requestToPayTransfer",
 							"host": [
 								"localhost"
 							],
@@ -875,7 +875,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:5002/requestToPayTransfer/{{transactionRequestId}}",
+							"raw": "localhost:5002/requestToPayTransfer/{{transactionRequestId}}",
 							"host": [
 								"localhost"
 							],
@@ -883,6 +883,124 @@
 							"path": [
 								"requestToPayTransfer",
 								"{{transactionRequestId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "ALS - GET parties",
+			"item": [
+				{
+					"name": "ALS GET /parties - MSISDN 123456789 Alice",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "90425afb-686d-4075-b678-cd357b2c9261",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.interoperability.parties+json;version=1.0",
+								"type": "text"
+							},
+							{
+								"key": "date",
+								"value": "{{dateHeader}}",
+								"type": "text"
+							},
+							{
+								"key": "fspiop-source",
+								"value": "pisp",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.parties+json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "localhost:5002/parties/MSISDN/123456789",
+							"host": [
+								"localhost"
+							],
+							"port": "5002",
+							"path": [
+								"parties",
+								"MSISDN",
+								"123456789"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ALS GET /parties - MSISDN 987654321 Bob",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "90425afb-686d-4075-b678-cd357b2c9261",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/vnd.interoperability.parties+json;version=1.0"
+							},
+							{
+								"key": "date",
+								"type": "text",
+								"value": "{{dateHeader}}"
+							},
+							{
+								"key": "fspiop-source",
+								"type": "text",
+								"value": "pisp"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/vnd.interoperability.parties+json"
+							}
+						],
+						"url": {
+							"raw": "localhost:4002/parties/MSISDN/987654321",
+							"host": [
+								"localhost"
+							],
+							"port": "4002",
+							"path": [
+								"parties",
+								"MSISDN",
+								"987654321"
 							]
 						}
 					},

--- a/docker-local/postman/PISP.postman_collection.json.postman_collection.json
+++ b/docker-local/postman/PISP.postman_collection.json.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4782e366-cbc6-45c0-b9c4-557042912b53",
+		"_postman_id": "a9e5e624-ed85-4861-bf83-99a853328454",
 		"name": "PISP.postman_collection.json",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -41,7 +41,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"displayName\": \"Alice Alpaca\",\n    \"firstName\": \"Alice\",\n    \"middleName\": \"K\",\n    \"lastName\": \"Alpaca\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"123456789\",\n    \"accounts\": [\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"savings\",\n\t\t  \"address\": \"moja.amber.53451233-b82a5456a-4fa9-838b-123456789\"\n\t\t},\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"checkings\",\n\t\t  \"address\": \"moja.amber.8f027046-b8236345a-4fa9-838b-123456789\"\n\t\t}\n\t]\n}",
+							"raw": "{\n    \"displayName\": \"Alice Alpaca\",\n    \"firstName\": \"Alice\",\n    \"middleName\": \"K\",\n    \"lastName\": \"Alpaca\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"123456789\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -88,7 +88,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"displayName\": \"Bob Babirusa\",\n    \"firstName\": \"Bob\",\n    \"middleName\": \"O\",\n    \"lastName\": \"Babirusa\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"987654321\",\n    \"accounts\": [\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"savings\",\n\t\t  \"address\": \"moja.burgundy.76542756-f49gk439f-6a5f-543d-987654321\"\n\t\t},\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"checkings\",\n\t\t  \"address\": \"moja.burgundy.43638980-f49gk439f-6a5f-543d-987654321\"\n\t\t}\n\t]\n}",
+							"raw": "{\n    \"displayName\": \"Bob Babirusa\",\n    \"firstName\": \"Bob\",\n    \"middleName\": \"O\",\n    \"lastName\": \"Babirusa\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"987654321\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -726,7 +726,7 @@
 							}
 						},
 						"url": {
-							"raw": "localhost:5002/requestToPayTransfer",
+							"raw": "http://localhost:5002//requestToPayTransfer",
 							"host": [
 								"localhost"
 							],
@@ -875,7 +875,7 @@
 							}
 						},
 						"url": {
-							"raw": "localhost:5002/requestToPayTransfer/{{transactionRequestId}}",
+							"raw": "http://localhost:5002/requestToPayTransfer/{{transactionRequestId}}",
 							"host": [
 								"localhost"
 							],
@@ -883,124 +883,6 @@
 							"path": [
 								"requestToPayTransfer",
 								"{{transactionRequestId}}"
-							]
-						}
-					},
-					"response": []
-				}
-			],
-			"protocolProfileBehavior": {}
-		},
-		{
-			"name": "ALS - GET parties",
-			"item": [
-				{
-					"name": "ALS GET /parties - MSISDN 123456789 Alice",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "90425afb-686d-4075-b678-cd357b2c9261",
-								"exec": [
-									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/vnd.interoperability.parties+json;version=1.0",
-								"type": "text"
-							},
-							{
-								"key": "date",
-								"value": "{{dateHeader}}",
-								"type": "text"
-							},
-							{
-								"key": "fspiop-source",
-								"value": "pisp",
-								"type": "text"
-							},
-							{
-								"key": "Accept",
-								"value": "application/vnd.interoperability.parties+json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "localhost:4002/parties/MSISDN/123456789",
-							"host": [
-								"localhost"
-							],
-							"port": "4002",
-							"path": [
-								"parties",
-								"MSISDN",
-								"123456789"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "ALS GET /parties - MSISDN 987654321 Bob",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"id": "90425afb-686d-4075-b678-cd357b2c9261",
-								"exec": [
-									"pm.test(\"Status code is 202\", function () {",
-									"    pm.response.to.have.status(202);",
-									"});",
-									""
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/vnd.interoperability.parties+json;version=1.0"
-							},
-							{
-								"key": "date",
-								"type": "text",
-								"value": "{{dateHeader}}"
-							},
-							{
-								"key": "fspiop-source",
-								"type": "text",
-								"value": "pisp"
-							},
-							{
-								"key": "Accept",
-								"type": "text",
-								"value": "application/vnd.interoperability.parties+json"
-							}
-						],
-						"url": {
-							"raw": "localhost:4002/parties/MSISDN/987654321",
-							"host": [
-								"localhost"
-							],
-							"port": "4002",
-							"path": [
-								"parties",
-								"MSISDN",
-								"987654321"
 							]
 						}
 					},

--- a/docker-local/postman/PISP.postman_collection.json.postman_collection.json
+++ b/docker-local/postman/PISP.postman_collection.json.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "a9e5e624-ed85-4861-bf83-99a853328454",
+		"_postman_id": "4782e366-cbc6-45c0-b9c4-557042912b53",
 		"name": "PISP.postman_collection.json",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -41,7 +41,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"displayName\": \"Alice Alpaca\",\n    \"firstName\": \"Alice\",\n    \"middleName\": \"K\",\n    \"lastName\": \"Alpaca\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"123456789\"\n}",
+							"raw": "{\n    \"displayName\": \"Alice Alpaca\",\n    \"firstName\": \"Alice\",\n    \"middleName\": \"K\",\n    \"lastName\": \"Alpaca\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"123456789\",\n    \"accounts\": [\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"savings\",\n\t\t  \"address\": \"moja.amber.53451233-b82a5456a-4fa9-838b-123456789\"\n\t\t},\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"checkings\",\n\t\t  \"address\": \"moja.amber.8f027046-b8236345a-4fa9-838b-123456789\"\n\t\t}\n\t]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -88,7 +88,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"displayName\": \"Bob Babirusa\",\n    \"firstName\": \"Bob\",\n    \"middleName\": \"O\",\n    \"lastName\": \"Babirusa\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"987654321\"\n}",
+							"raw": "{\n    \"displayName\": \"Bob Babirusa\",\n    \"firstName\": \"Bob\",\n    \"middleName\": \"O\",\n    \"lastName\": \"Babirusa\",\n    \"dateOfBirth\": \"1970-01-01\",\n    \"idType\": \"MSISDN\",\n    \"idValue\": \"987654321\",\n    \"accounts\": [\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"savings\",\n\t\t  \"address\": \"moja.burgundy.76542756-f49gk439f-6a5f-543d-987654321\"\n\t\t},\n\t\t{ \"currency\": \"USD\",\n\t\t  \"description\": \"checkings\",\n\t\t  \"address\": \"moja.burgundy.43638980-f49gk439f-6a5f-543d-987654321\"\n\t\t}\n\t]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -726,7 +726,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:5002//requestToPayTransfer",
+							"raw": "localhost:5002/requestToPayTransfer",
 							"host": [
 								"localhost"
 							],
@@ -875,7 +875,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:5002/requestToPayTransfer/{{transactionRequestId}}",
+							"raw": "localhost:5002/requestToPayTransfer/{{transactionRequestId}}",
 							"host": [
 								"localhost"
 							],
@@ -883,6 +883,124 @@
 							"path": [
 								"requestToPayTransfer",
 								"{{transactionRequestId}}"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "ALS - GET parties",
+			"item": [
+				{
+					"name": "ALS GET /parties - MSISDN 123456789 Alice",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "90425afb-686d-4075-b678-cd357b2c9261",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/vnd.interoperability.parties+json;version=1.0",
+								"type": "text"
+							},
+							{
+								"key": "date",
+								"value": "{{dateHeader}}",
+								"type": "text"
+							},
+							{
+								"key": "fspiop-source",
+								"value": "pisp",
+								"type": "text"
+							},
+							{
+								"key": "Accept",
+								"value": "application/vnd.interoperability.parties+json",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "localhost:4002/parties/MSISDN/123456789",
+							"host": [
+								"localhost"
+							],
+							"port": "4002",
+							"path": [
+								"parties",
+								"MSISDN",
+								"123456789"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "ALS GET /parties - MSISDN 987654321 Bob",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "90425afb-686d-4075-b678-cd357b2c9261",
+								"exec": [
+									"pm.test(\"Status code is 202\", function () {",
+									"    pm.response.to.have.status(202);",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/vnd.interoperability.parties+json;version=1.0"
+							},
+							{
+								"key": "date",
+								"type": "text",
+								"value": "{{dateHeader}}"
+							},
+							{
+								"key": "fspiop-source",
+								"type": "text",
+								"value": "pisp"
+							},
+							{
+								"key": "Accept",
+								"type": "text",
+								"value": "application/vnd.interoperability.parties+json"
+							}
+						],
+						"url": {
+							"raw": "localhost:4002/parties/MSISDN/987654321",
+							"host": [
+								"localhost"
+							],
+							"port": "4002",
+							"path": [
+								"parties",
+								"MSISDN",
+								"987654321"
 							]
 						}
 					},


### PR DESCRIPTION
I'm just realizing (maybe I'm mistaken) that
- sdk-scheme-adapter doesn't have it's own `/parties` endpoint so that a dfsp back-end can get party accounts synchronously?
- `mojaloop-simulator` doesn't seem to have a scenario that covers if a dfsp want to query the ALS for a party?

So I'm not sure how to write tests. Maybe @bushjames you can guide me.