### PR TITLE
chore(swagger): remove invalid currency property

### DIFF
--- a/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
+++ b/docs/fspiop-rest-v1.0-OpenAPI-implementation_openapi3.yaml
@@ -2666,7 +2666,6 @@ components:
       - authenticationType
       - retriesLeft
       - amount
-      - currency
       - transactionId
       - transactionRequestId
       - quote


### PR DESCRIPTION
I removed the property `currency` from list of required because there is no appropriate definition at the root level of the request body. Of course, there is `currency` in `amount` field