### PR TITLE
Update Unlinking Flow

### DIFF
--- a/docs/linking/unlinking.puml
+++ b/docs/linking/unlinking.puml
@@ -25,7 +25,7 @@ end note
 
 ...
 
-PISP -> Switch ++: ""DELETE /consents/123""
+PISP -> Switch ++: ""POST /consents/123/revoke""
 Switch --> PISP: ""202 Accepted""
 deactivate PISP
 


### PR DESCRIPTION
Changed Request sent from PISP to Switch from `DELETE consent/{ID}` to `POST /consents/{ID}/revoke`