### PR TITLE
chore: add todo tests for pisp transaction flow

### DIFF
--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -4,26 +4,31 @@ This document is suggesting that a high level error category 6xxx(can be another
 
 - **Third Party Error** -- **60**_xx_
 
-| **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations |
-| --- | --- | --- | --- | --- | --- | --- |
-| **6000** | Third party error | Generic third party error. | X | X | X | X |
-| **6001** | Third party request error | Third party request failed. | X | X | X | X |
+| **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations | /consents |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **6000** | Third party error | Generic third party error. | X | X | X | X | X |
+| **6001** | Third party request error | Third party request failed. | X | X | X | X | X |
 
 - **Permission Error** -- **61**_xx_
 
-| **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations |
-| --- | --- | --- | --- | --- | --- | --- |
-| **6100** | Authentication rejection | Generic authentication rejection |  |  | X | X |
-| **6101** | Unsupported authentication channel | Authentication request is attempting to authorize with an authentication channel that the DFSP does not support. Example Web, OTP. |  |  |  | X |
-| **6102** | Unsupported scopes were requested | Authentication request is attempting to get authorization for scopes that the DFSP doesn’t allow/support |  | |  | X |
-| **6103** | Consent not given | DFSP denies user gave consent or DFSP says user has revoked consent. |  |  | X |  |
+| **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations | /consents |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **6100** | Authentication rejection | Generic authentication rejection |  |  | X | X |  |
+| **6101** | Unsupported authentication channel | Authentication request is attempting to authorize with an authentication channel that the DFSP does not support. Example Web, OTP. |  |  |  | X |  |
+| **6102** | Unsupported scopes were requested | Authentication request is attempting to get authorization for scopes that the DFSP doesn’t allow/support |  | |  | X |  |
+| **6103** | Consent not given | DFSP denies user gave consent or DFSP says user has revoked consent. |  |  | X |  |  |
 
 - **Validation Error** -- **62**_xx_
 
-| **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations |
-| --- | --- | --- | --- | --- | --- | --- |
-| **6200** | Validation error | Generic validation error. | X | X | X | X |
-| **6201** | Invalid signed challenge | PISP server receives signed challenge that does not match the original challenge. |  |  |  | X |
-| **6202** | Missing authentication credential | Payload received with missing authentication credential.  |  |  |  | X |
-| **6203** | Invalid authentication token | DFSP receives invalid authentication token from PISP.  |  |  |  | X |
-| **6204** | OTP is incorrect | One time password is incorrect.  |  |  |  |X|
+| **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations | /consents |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| **6200** | Validation error | Generic validation error. | X | X | X | X | X |
+| **6201** | Malformed syntax | Generic validation error. | X | X | X | X | X |
+| **6202** | Missing mandatory element | The format of the parameter is not valid. For example, amount set to 5.ABC. The error description field should specify which element is erroneous | X | X | X | X | X |
+| **6203** | Too many elements | The number of elements of an array exceeds the maximum number allowed. |  |  |  |  | X |
+| **6204** | Invalid signed challenge | PISP server receives signed challenge that does not match the original challenge. |  |  |  | X |  |
+| **6205** | Missing authentication credential | Payload received with missing authentication credential.  |  |  |  | X |  |  |
+| **6206** | Invalid authentication token | DFSP receives invalid authentication token from PISP.  |  |  |  | X |  |
+| **6207** | OTP is incorrect | One time password is incorrect.  |  |  |  | X |  |
+| **6208** | OTP is incorrect | One time password is incorrect.  |  |  |  | X |  |
+| **6209** | Mismatched thirdparty ID | Thirdparty ID doesn't match corresponding thirdparty request.  |  |  |  | X |  |

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -17,6 +17,8 @@ This document is suggesting that a high level error category 6xxx(can be another
 | **6101** | Unsupported authentication channel | Authentication request is attempting to authorize with an authentication channel that the DFSP does not support. Example Web, OTP. |  |  | X | X |  |
 | **6102** | Unsupported scopes were requested | Authentication request is attempting to get authorization for scopes that the DFSP doesn’t allow/support |  |  | X | X |  |
 | **6103** | Consent not given | DFSP denies user gave consent or DFSP says user has revoked consent. |  |  | X |  |  |
+| **6104** | Consent not valid | DFSP denies user has valid consent with correct credentials. |  | X | X |  |  |
+| **6105** | Thirdparty request rejection | DFSP catch all error used when it rejects a thirdparty request. |  | X | X | X | X |
 
 - **Validation Error** -- **62**_xx_
 
@@ -26,8 +28,9 @@ This document is suggesting that a high level error category 6xxx(can be another
 | **6201** | Malformed syntax | Generic validation error. | X | X | X | X | X |
 | **6202** | Missing mandatory element | The format of the parameter is not valid. For example, amount set to 5.ABC. The error description field should specify which element is erroneous | X | X | X | X | X |
 | **6203** | Too many elements | The number of elements of an array exceeds the maximum number allowed. | X |  | X |  | X |
-| **6204** | Invalid signed challenge | PISP server receives signed challenge that does not match the original challenge. |  |  |  | X |  |
-| **6205** | Missing authentication credential | Payload received with missing authentication credential.  |  |  |  | X |  |  |
-| **6206** | Invalid authentication token | DFSP receives invalid authentication token from PISP.  |  |  |  | X |  |
-| **6207** | OTP is incorrect | One time password is incorrect.  |  |  |  | X |  |
-| **6208** | Mismatched thirdparty ID | Thirdparty ID doesn't match corresponding thirdparty request.  |  |  |  | X |  |
+| **6204** | Invalid signed challenge | PISP server/DFSP receives signed challenge that is invalid. |  |  | X | X |  |
+| **6205** | Maximum authorization retires reached | PISP server has reached maximum number of authorizations. |  |  | X | X |  |
+| **6206** | Missing authentication credential | Payload received with missing authentication credential.  |  |  |  | X |  |  |
+| **6207** | Invalid authentication token | DFSP receives invalid authentication token from PISP.  |  |  |  | X |  |
+| **6208** | OTP is incorrect | One time password is incorrect.  |  |  |  | X |  |
+| **6209** | Mismatched thirdparty ID | Thirdparty ID doesn't match corresponding thirdparty request.  |  |  |  | X |  |

--- a/docs/error_codes.md
+++ b/docs/error_codes.md
@@ -14,8 +14,8 @@ This document is suggesting that a high level error category 6xxx(can be another
 | **Error Code** | **Name** | **Description** | /parties | /thirdPartyRequest | /consentRequests | /authorizations | /consents |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | **6100** | Authentication rejection | Generic authentication rejection |  |  | X | X |  |
-| **6101** | Unsupported authentication channel | Authentication request is attempting to authorize with an authentication channel that the DFSP does not support. Example Web, OTP. |  |  |  | X |  |
-| **6102** | Unsupported scopes were requested | Authentication request is attempting to get authorization for scopes that the DFSP doesn’t allow/support |  | |  | X |  |
+| **6101** | Unsupported authentication channel | Authentication request is attempting to authorize with an authentication channel that the DFSP does not support. Example Web, OTP. |  |  | X | X |  |
+| **6102** | Unsupported scopes were requested | Authentication request is attempting to get authorization for scopes that the DFSP doesn’t allow/support |  |  | X | X |  |
 | **6103** | Consent not given | DFSP denies user gave consent or DFSP says user has revoked consent. |  |  | X |  |  |
 
 - **Validation Error** -- **62**_xx_
@@ -25,10 +25,9 @@ This document is suggesting that a high level error category 6xxx(can be another
 | **6200** | Validation error | Generic validation error. | X | X | X | X | X |
 | **6201** | Malformed syntax | Generic validation error. | X | X | X | X | X |
 | **6202** | Missing mandatory element | The format of the parameter is not valid. For example, amount set to 5.ABC. The error description field should specify which element is erroneous | X | X | X | X | X |
-| **6203** | Too many elements | The number of elements of an array exceeds the maximum number allowed. |  |  |  |  | X |
+| **6203** | Too many elements | The number of elements of an array exceeds the maximum number allowed. | X |  | X |  | X |
 | **6204** | Invalid signed challenge | PISP server receives signed challenge that does not match the original challenge. |  |  |  | X |  |
 | **6205** | Missing authentication credential | Payload received with missing authentication credential.  |  |  |  | X |  |  |
 | **6206** | Invalid authentication token | DFSP receives invalid authentication token from PISP.  |  |  |  | X |  |
 | **6207** | OTP is incorrect | One time password is incorrect.  |  |  |  | X |  |
-| **6208** | OTP is incorrect | One time password is incorrect.  |  |  |  | X |  |
-| **6209** | Mismatched thirdparty ID | Thirdparty ID doesn't match corresponding thirdparty request.  |  |  |  | X |  |
+| **6208** | Mismatched thirdparty ID | Thirdparty ID doesn't match corresponding thirdparty request.  |  |  |  | X |  |

--- a/test/e2e/PISPTransferFailure.test.ts
+++ b/test/e2e/PISPTransferFailure.test.ts
@@ -31,6 +31,13 @@ describe('PISP initiated transfer failure', (): void => {
     // this error should apply for all mandatory fields like transactionRequestId/payer/payee/etc
     // ideally when hapi openapi throws a missing required error it is reformated into a standard mojaloop error object
     it.todo('receives a missing mandatory element error callback when PISP sends missing payer element from payload. tentative code 6202.')
+
+    it.todo('receives a consent not valid error callback when PISP sends incorrect or not existent consentId. tentative code 6103.')
+
+    // tentative errors for bubbling up downstream errors
+    it.todo('receives a thirdparty request rejection error callback if source account has insufficient funds for transfer. tentative code 6105.')
+    it.todo('receives a thirdparty request rejection error callback if downstream quote fails. tentative code 6105.')
+    it.todo('receives a generic third party error callback if downstream transfer fails. tentative code 6000.')
   })
 
   describe('3. PISP PUT /authorizations/{ID} response', (): void => {
@@ -41,6 +48,12 @@ describe('PISP initiated transfer failure', (): void => {
     // ideally when hapi openapi throws a missing required error it is reformated into a standard mojaloop error object
     it.todo('receives a missing mandatory element error callback from switch when PISP sends missing authenticationInfo element from payload. tentative code 6202.')
 
-    it.todo('receives a  Mismatched thirdparty ID error callback if dfsp errors on checking that /authorization/{UUID} pispId does not match associated /thirdpartyRequest/transaction/{UUID}. tentative code 6208')
+    it.todo('receives a mismatched thirdparty ID error callback if dfsp errors on checking that /authorization/{UUID} pispId does not match associated /thirdpartyRequest/transaction/{UUID}. tentative code 6209')
+
+    // tentative errors for bubbling up downstream errors
+    it.todo('receives a invalid signed challenge error callback if dfsp tries to validate signed challenge with auth service and it is not valid. tentative code 6204.')
+    it.todo('receives a thirdparty request rejection error callback if sourceAccountId is no longer valid. tentative code 6105.')
+    it.todo('receives a thirdparty request rejection error callback if source account has insufficient funds for transfer. tentative code 6105.')
+    it.todo('receives a maximum authorization retires reached error callback if authorization counter has passed the set limit. tentative code 6205.')
   })
 })

--- a/test/e2e/PISPTransferFailure.test.ts
+++ b/test/e2e/PISPTransferFailure.test.ts
@@ -37,7 +37,6 @@ describe('PISP initiated transfer failure', (): void => {
     // tentative errors for bubbling up downstream errors
     it.todo('receives a thirdparty request rejection error callback if source account has insufficient funds for transfer. tentative code 6105.')
     it.todo('receives a thirdparty request rejection error callback if downstream quote fails. tentative code 6105.')
-    it.todo('receives a generic third party error callback if downstream transfer fails. tentative code 6000.')
   })
 
   describe('3. PISP PUT /authorizations/{ID} response', (): void => {
@@ -55,5 +54,6 @@ describe('PISP initiated transfer failure', (): void => {
     it.todo('receives a thirdparty request rejection error callback if sourceAccountId is no longer valid. tentative code 6105.')
     it.todo('receives a thirdparty request rejection error callback if source account has insufficient funds for transfer. tentative code 6105.')
     it.todo('receives a maximum authorization retires reached error callback if authorization counter has passed the set limit. tentative code 6205.')
+    it.todo('receives a generic third party error callback if downstream transfer fails. tentative code 6000.')
   })
 })

--- a/test/e2e/PISPTransferFailure.test.ts
+++ b/test/e2e/PISPTransferFailure.test.ts
@@ -10,27 +10,6 @@ describe('PISP initiated transfer failure', (): void => {
     it.todo('receives a communication error callback. code 1000.')
     it.todo('receives a destination communication error callback. code 1001.')
 
-    // sent by the switch when the switch is unable to fulfil a valid request
-    // believe a PISP should know about these errors
-    it.todo('receives a generic server error callback. code 2000.')
-    it.todo('receives an internal server error callback. code 2001.')
-    // sent if switch's ALS is down?
-    it.todo('receives a service unavailable error callback.  code 2003.')
-    it.todo('receives a server timed out error callback. code 2004.')
-    // unsure how to test.
-    it.todo('receives a server busy error callback. code 2005.')
-
-    // unsure what triggers these error.
-    it.todo('receives a generic client error callback. code 3000.')
-    it.todo('receives an unacceptable version requested error callback. code 3001.')
-
-    // don't believe these can occur from a GET parties scenario?
-    it.todo('receives a generic validation error callback. code 3100.')
-    it.todo('receives a malformed syntax error callback. code 3101.')
-    it.todo('receives a missing mandatory syntax error callback. code 3102.')
-    it.todo('receives a too large payload error callback from switch when PISP sends request with too large of payload. code 3104.')
-    it.todo('receives an invalid signature error callback. code 3105.')
-
     // believe a PISP would need to know about these errors
     it.todo('receives a generic id not found error callback from switch when DFSP is not able to find party related to identifier. code 3200.')
     it.todo('receives a destination fsp not found error callback from switch when DFSP is not found as a participant. code 3201.')

--- a/test/e2e/PISPTransferFailure.test.ts
+++ b/test/e2e/PISPTransferFailure.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @name PISPTransferFailure
+ * @description PISP End To End Tests
+ */
+
+describe('PISP initiated transfer failure', (): void => {
+  describe('1. PISP GET /parties response', (): void => {
+    // sent by the switch when a peer fsp can't be reached
+    // unsure where these error codes are used
+    it.todo('receives a communication error callback. code 1000.')
+    it.todo('receives a destination communication error callback. code 1001.')
+
+    // sent by the switch when the switch is unable to fulfil a valid request
+    // believe a PISP should know about these errors
+    it.todo('receives a generic server error callback. code 2000.')
+    it.todo('receives an internal server error callback. code 2001.')
+    // sent if switch's ALS is down?
+    it.todo('receives a service unavailable error callback.  code 2003.')
+    it.todo('receives a server timed out error callback. code 2004.')
+    // unsure how to test.
+    it.todo('receives a server busy error callback. code 2005.')
+
+    // unsure what triggers these error.
+    it.todo('receives a generic client error callback. code 3000.')
+    it.todo('receives an unacceptable version requested error callback. code 3001.')
+
+    // don't believe these can occur from a GET parties scenario?
+    it.todo('receives a generic validation error callback. code 3100.')
+    it.todo('receives a malformed syntax error callback. code 3101.')
+    it.todo('receives a missing mandatory syntax error callback. code 3102.')
+    it.todo('receives a too large payload error callback from switch when PISP sends request with too large of payload. code 3104.')
+    it.todo('receives an invalid signature error callback. code 3105.')
+
+    // believe a PISP would need to know about these errors
+    it.todo('receives a generic id not found error callback from switch when DFSP is not able to find party related to identifier. code 3200.')
+    it.todo('receives a destination fsp not found error callback from switch when DFSP is not found as a participant. code 3201.')
+    it.todo('receives a party not found error callback from switch when DFSP is not able to find party related to identifier, type and sub id/type. code 3204.')
+  })
+
+  describe('2. PISP POST /thirdpartyRequests/transactions response', (): void => {
+    // believe for /thirdpartyRequests/transactions the idea is that a PISP
+    // only needs to know if a thirdpartyRequest failed or succeeded.
+    it.todo('receives a generic third party error callback. tentative code 6000.')
+    it.todo('receives a generic third party request failed error callback. tentative code 6001.')
+
+    // standard validation errors
+    it.todo('receives a generic validation error callback. tentative code 6200.')
+
+    // this error might apply to fields other than amount
+    it.todo('receives a malformed syntax error callback from switch when PISP sends amount value 5.ABC which does not match regex pattern. tentative code 6201.')
+
+    // this error should apply for all mandatory fields like transactionRequestId/payer/payee/etc
+    // ideally when hapi openapi throws a missing required error it is reformated into a standard mojaloop error object
+    it.todo('receives a missing mandatory element error callback when PISP sends missing payer element from payload. tentative code 6202.')
+  })
+
+  describe('3. PISP PUT /authorizations/{ID} response', (): void => {
+    // would be unlikely that a fsp not be identified this late in the process but it could still happen?
+    it.todo('receives a destination fsp not found error callback from switch when DFSP is not found as a participant. code 3201.')
+
+    // this error should apply for all mandatory fields like authenticationInfo/response type
+    // ideally when hapi openapi throws a missing required error it is reformated into a standard mojaloop error object
+    it.todo('receives a missing mandatory element error callback from switch when PISP sends missing authenticationInfo element from payload. tentative code 6202.')
+
+    it.todo('receives a  Mismatched thirdparty ID error callback if dfsp errors on checking that /authorization/{UUID} pispId does not match associated /thirdpartyRequest/transaction/{UUID}. tentative code 6208')
+  })
+})


### PR DESCRIPTION
:( Honestly don't feel very confident about this. feels like a shot in the dark.
Instead of pondering too long I'm opening up the review.

definitely need to give `error_codes.md` another pass but I've kept this pr to address the transaction flow errors...