### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 
-*   @kleyow @eoln @lewisdaly @sridharvoruganti
+*   @kleyow @eoln @lewisdaly @sridharvoruganti @elnyry-sam-k

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
 
 *   @kleyow @eoln @lewisdaly @sridharvoruganti
-docs/*  @lewisdaly @jgeewax @MichaelJBRichards 


### PR DESCRIPTION
remove the separate entry for `./docs/*`, it's getting too confusing to manage